### PR TITLE
Mark result factory as public and increment version in advance of nuget publish step.

### DIFF
--- a/src/JsonSchemaValidator/Sarif/ResultFactory.cs
+++ b/src/JsonSchemaValidator/Sarif/ResultFactory.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Json.Schema.JsonSchemaValidator.Sarif
 {
-    internal partial class ResultFactory
+    public partial class ResultFactory
     {
         private const string ErrorCodeFormat = "JS{0:D4}";
 

--- a/src/build/CurrentVersion.xml
+++ b/src/build/CurrentVersion.xml
@@ -1,6 +1,6 @@
 <CurrentVersion>
   <Major>0</Major>
-  <Minor>50</Minor>
+  <Minor>51</Minor>
   <Patch>0</Patch>
   <PreRelease></PreRelease>
 </CurrentVersion>


### PR DESCRIPTION
@lgolding @vinaykapadia 

The ResultFactory type had to be duplicated in the SARIF project due to lack of accessibility.