### PR TITLE
Fix unicode character substitution

### DIFF
--- a/src/build.props
+++ b/src/build.props
@@ -12,7 +12,7 @@
   <PropertyGroup Label="AssemblyAttributes">
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
-    <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright Condition=" '$(Copyright)' == '' ">Â© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>0.56.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>


### PR DESCRIPTION
Diff doesn't show it, but this file was not properly persisted as UTF8.

@lgolding fyi. This is the final blocker to nuget update, so pushing forward.