### PR TITLE
Use WriteAllText because Set-Content intermittently fails.

### DIFF
--- a/src/build/New-VersionConstantsFile.ps1
+++ b/src/build/New-VersionConstantsFile.ps1
@@ -38,4 +38,6 @@ if (-not (Test-Path $outputDirectory)) {
     New-Item -Type Directory $outputDirectory | Out-Null
 }
 
-Set-Content $outputFile $versionConstantsFileContents
+# We use .NET rather than the PowerShell Set-Content cmdlet because Set-Content
+# intermittently fails with "Stream was not readable".
+[System.IO.File]::WriteAllText($outputFile, $versionConstantsFileContents)


### PR DESCRIPTION
It is a known problem that `Set-Content` sometimes fails in PowerShell scripts, so use .NET `System.IO.File.WriteAllText` instead.

We recently made a similar change in the sarif-sdk repo.