### PR TITLE
Add dotnet publish step to build.

### DIFF
--- a/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.csproj
+++ b/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.csproj
@@ -8,6 +8,7 @@
   <PropertyGroup Label="AssemblyAttributes">
     <AssemblyTitle>JSON Schema To .NET Code Generation Tool</AssemblyTitle>
     <Description>Command line tool to generate a set of .NET classes from a JSON Schema</Description>
+    <RootNamespaceOverride>Microsoft.Json.Schema.ToDotNet.CommandLine</RootNamespaceOverride>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
+++ b/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
@@ -28,7 +28,7 @@
           target="tools\net461"
           />
     
-    <file src="bld\bin\$platform$_$configuration$\Json.Schema.ToDotNet.Cli\netcoreapp2.0\**"
+    <file src="bld\bin\$platform$_$configuration$\Json.Schema.ToDotNet.Cli\netcoreapp2.0\publish\**"
           target="tools\netcoreapp2.0"
           />
 

--- a/src/Json.Schema.ToDotNet.Cli/Options.cs
+++ b/src/Json.Schema.ToDotNet.Cli/Options.cs
@@ -3,7 +3,7 @@
 
 using CommandLine;
 
-namespace Microsoft.Json.Schema.ToDotNet.Cli
+namespace Microsoft.Json.Schema.ToDotNet.CommandLine
 {
     internal class Options
     {

--- a/src/Json.Schema.ToDotNet.Cli/Program.cs
+++ b/src/Json.Schema.ToDotNet.Cli/Program.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using CommandLine;
 using Microsoft.Json.Schema.ToDotNet.Hints;
 
-namespace Microsoft.Json.Schema.ToDotNet.Cli
+namespace Microsoft.Json.Schema.ToDotNet.CommandLine
 {
     internal class Program
     {

--- a/src/Json.Schema.ToDotNet.Cli/Resources.Designer.cs
+++ b/src/Json.Schema.ToDotNet.Cli/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Json.Schema.ToDotNet.Cli {
+namespace Microsoft.Json.Schema.ToDotNet.CommandLine {
     using System;
     
     

--- a/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.csproj
+++ b/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.csproj
@@ -8,7 +8,8 @@
   <PropertyGroup Label="AssemblyAttributes">
     <AssemblyTitle>JSON Schema Validation Tool</AssemblyTitle>
     <Description>Command line tool to validate a JSON instance against a JSON Schema</Description>
-  </PropertyGroup>
+    <RootNamespaceOverride>Microsoft.Json.Schema.Validation.CommandLine</RootNamespaceOverride>
+   </PropertyGroup>
 
   <PropertyGroup Label="Package">
     <IsTool>true</IsTool>

--- a/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
+++ b/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
@@ -28,7 +28,7 @@
           target="tools\net461"
           />
 
-    <file src="bld\bin\$platform$_$configuration$\Json.Schema.Validation.Cli\netcoreapp2.0\**"
+    <file src="bld\bin\$platform$_$configuration$\Json.Schema.Validation.Cli\netcoreapp2.0\publish\**"
           target="tools\netcoreapp2.0"
           />
 

--- a/src/Json.Schema.Validation.Cli/Options.cs
+++ b/src/Json.Schema.Validation.Cli/Options.cs
@@ -3,7 +3,7 @@
 
 using CommandLine;
 
-namespace Microsoft.Json.Schema.Validation.Cli
+namespace Microsoft.Json.Schema.Validation.CommandLine
 {
     internal class Options
     {

--- a/src/Json.Schema.Validation.Cli/Program.cs
+++ b/src/Json.Schema.Validation.Cli/Program.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 using Microsoft.Json.Schema.Validation;
 
-namespace Microsoft.Json.Schema.Validation.Cli
+namespace Microsoft.Json.Schema.Validation.CommandLine
 {
     internal class Program
     {

--- a/src/Json.Schema.Validation.Cli/ValidatorResources.Designer.cs
+++ b/src/Json.Schema.Validation.Cli/ValidatorResources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Json.Schema.Validation.Cli {
+namespace Microsoft.Json.Schema.Validation.CommandLine {
     using System;
     
     

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,3 +6,5 @@
 ## **0.58.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/0.58.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/0.58.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/0.58.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/0.58.0)
 * Package validation and .NET object model generation utilities in Validation and ToDotNet packages.
 
+## **0.59.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/0.59.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/0.59.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/0.59.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/0.59.0)
+* Add missing runtime dependencies to Validation and ToDotNet packages.

--- a/src/build.props
+++ b/src/build.props
@@ -13,13 +13,14 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>0.58.0</VersionPrefix>
+    <VersionPrefix>0.59.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
     <AssemblyName>Microsoft.$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
+    <RootNamespace Condition=" '$(RootNamespaceOverride)' != '' ">$(RootNamespaceOverride)</RootNamespace>
     <OutputSubDir>$(Platform)_$(Configuration)</OutputSubDir>
     <IntermediateOutputPath>$(MsBuildThisFileDirectory)..\bld\obj\$(MSBuildProjectName)\$(OutputSubDir)\</IntermediateOutputPath>
     <OutputPath>$(MsBuildThisFileDirectory)..\bld\bin\$(OutputSubDir)\$(MSBuildProjectName)\</OutputPath>


### PR DESCRIPTION
Also:
- Use `.CommandLine`, not `.Cli` in the command line tool namespaces. @michaelcfanning pointed out that my change to `.Cli` violated .NET naming guidelines.

The reason I did it was to have consistency between the assembly name and the namespace name. But Michael wants the assembly (the tool executable) to be named `.Cli`, and the namespace to be named `.CommandLine`. So I have to restore a bit of build logic I removed in the previous PR, namely, the ability to override the default namespace assigned by the project system.