### PR TITLE
Fix #39: ToDotNet application can't find its resources

### DIFF
--- a/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.csproj
+++ b/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.csproj
@@ -26,4 +26,19 @@
     <ProjectReference Include="..\Json.Schema\Json.Schema.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
When you run the ToDotNet command line app, it fails because it can't find the resource stream. Somehow the `.resx` and the `.Resources.designer` files got separated in the project file. Fix the project file to connect the resources back up.