### PR TITLE
Fix #45: Pass dictionary key to dictionary element visitors.

### DIFF
--- a/src/Json.Schema.ToDotNet.Cli/Resources.Designer.cs
+++ b/src/Json.Schema.ToDotNet.Cli/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Json.Schema.ToDotNet.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -1401,9 +1401,9 @@ namespace N
         /// <returns>
         /// A rewritten instance of the node.
         /// </returns>
-        public virtual object Visit(ISNode node)
+        public virtual object Visit(ISNode node, string key = null)
         {
-            return this.VisitActual(node);
+            return this.VisitActual(node, key);
         }
 
         /// <summary>
@@ -1415,7 +1415,7 @@ namespace N
         /// <returns>
         /// A rewritten instance of the node.
         /// </returns>
-        public virtual object VisitActual(ISNode node)
+        public virtual object VisitActual(ISNode node, string key = null)
         {
             if (node == null)
             {
@@ -1425,34 +1425,34 @@ namespace N
             switch (node.SNodeKind)
             {
                 case SNodeKind.C:
-                    return VisitC((C)node);
+                    return VisitC((C)node, key);
                 case SNodeKind.D:
-                    return VisitD((D)node);
+                    return VisitD((D)node, key);
                 default:
                     return node;
             }
         }
 
-        private T VisitNullChecked<T>(T node) where T : class, ISNode
+        private T VisitNullChecked<T>(T node, string key = null) where T : class, ISNode
         {
             if (node == null)
             {
                 return null;
             }
 
-            return (T)Visit(node);
+            return (T)Visit(node, key);
         }
 
-        public virtual C VisitC(C node)
+        public virtual C VisitC(C node, string key = null)
         {
             if (node != null)
             {
-                node.ReferencedTypeProp = VisitNullChecked(node.ReferencedTypeProp);
+                node.ReferencedTypeProp = VisitNullChecked(node.ReferencedTypeProp, key);
                 if (node.ArrayOfRefProp != null)
                 {
                     for (int index_0 = 0; index_0 < node.ArrayOfRefProp.Count; ++index_0)
                     {
-                        node.ArrayOfRefProp[index_0] = VisitNullChecked(node.ArrayOfRefProp[index_0]);
+                        node.ArrayOfRefProp[index_0] = VisitNullChecked(node.ArrayOfRefProp[index_0], key);
                     }
                 }
 
@@ -1465,7 +1465,7 @@ namespace N
                         {
                             for (int index_1 = 0; index_1 < value_0.Count; ++index_1)
                             {
-                                value_0[index_1] = VisitNullChecked(value_0[index_1]);
+                                value_0[index_1] = VisitNullChecked(value_0[index_1], key);
                             }
                         }
                     }
@@ -1474,12 +1474,12 @@ namespace N
                 if (node.DictionaryWithObjectSchemaProp != null)
                 {
                     var keys = node.DictionaryWithObjectSchemaProp.Keys.ToArray();
-                    foreach (var key in keys)
+                    foreach (var dictionaryKey in keys)
                     {
-                        var value = node.DictionaryWithObjectSchemaProp[key];
+                        var value = node.DictionaryWithObjectSchemaProp[dictionaryKey];
                         if (value != null)
                         {
-                            node.DictionaryWithObjectSchemaProp[key] = VisitNullChecked(value);
+                            node.DictionaryWithObjectSchemaProp[dictionaryKey] = VisitNullChecked(value, dictionaryKey);
                         }
                     }
                 }
@@ -1487,14 +1487,14 @@ namespace N
                 if (node.DictionaryWithObjectArraySchemaProp != null)
                 {
                     var keys = node.DictionaryWithObjectArraySchemaProp.Keys.ToArray();
-                    foreach (var key in keys)
+                    foreach (var dictionaryKey in keys)
                     {
-                        var value = node.DictionaryWithObjectArraySchemaProp[key];
+                        var value = node.DictionaryWithObjectArraySchemaProp[dictionaryKey];
                         if (value != null)
                         {
-                            for (int index_0 = 0; index_0 < node.DictionaryWithObjectArraySchemaProp[key].Count; ++index_0)
+                            for (int index_0 = 0; index_0 < node.DictionaryWithObjectArraySchemaProp[dictionaryKey].Count; ++index_0)
                             {
-                                node.DictionaryWithObjectArraySchemaProp[key][index_0] = VisitNullChecked(node.DictionaryWithObjectArraySchemaProp[key][index_0]);
+                                node.DictionaryWithObjectArraySchemaProp[dictionaryKey][index_0] = VisitNullChecked(node.DictionaryWithObjectArraySchemaProp[dictionaryKey][index_0], dictionaryKey);
                             }
                         }
                     }
@@ -1503,12 +1503,12 @@ namespace N
                 if (node.DictionaryWithUriKeyProp != null)
                 {
                     var keys = node.DictionaryWithUriKeyProp.Keys.ToArray();
-                    foreach (var key in keys)
+                    foreach (var dictionaryKey in keys)
                     {
-                        var value = node.DictionaryWithUriKeyProp[key];
+                        var value = node.DictionaryWithUriKeyProp[dictionaryKey];
                         if (value != null)
                         {
-                            node.DictionaryWithUriKeyProp[key] = VisitNullChecked(value);
+                            node.DictionaryWithUriKeyProp[dictionaryKey] = VisitNullChecked(value, dictionaryKey);
                         }
                     }
                 }
@@ -1517,7 +1517,7 @@ namespace N
             return node;
         }
 
-        public virtual D VisitD(D node)
+        public virtual D VisitD(D node, string key = null)
         {
             if (node != null)
             {
@@ -2657,9 +2657,9 @@ namespace N
         /// <returns>
         /// A rewritten instance of the node.
         /// </returns>
-        public virtual object Visit(ISNode node)
+        public virtual object Visit(ISNode node, string key = null)
         {
-            return this.VisitActual(node);
+            return this.VisitActual(node, key);
         }
 
         /// <summary>
@@ -2671,7 +2671,7 @@ namespace N
         /// <returns>
         /// A rewritten instance of the node.
         /// </returns>
-        public virtual object VisitActual(ISNode node)
+        public virtual object VisitActual(ISNode node, string key = null)
         {
             if (node == null)
             {
@@ -2681,23 +2681,23 @@ namespace N
             switch (node.SNodeKind)
             {
                 case SNodeKind.C:
-                    return VisitC((C)node);
+                    return VisitC((C)node, key);
                 default:
                     return node;
             }
         }
 
-        private T VisitNullChecked<T>(T node) where T : class, ISNode
+        private T VisitNullChecked<T>(T node, string key = null) where T : class, ISNode
         {
             if (node == null)
             {
                 return null;
             }
 
-            return (T)Visit(node);
+            return (T)Visit(node, key);
         }
 
-        public virtual C VisitC(C node)
+        public virtual C VisitC(C node, string key = null)
         {
             if (node != null)
             {


### PR DESCRIPTION
We modify the `RewritingVisitorGenerator` class so that every visit to a property of the object model receives an extra parameter called `key`. `key` is usually `null`. But within a visit to a dictionary, `key` is set to the dictionary key as each dictionary element is visited.

This has two consequences, one desirable and the other perhaps not. @michaelcfanning. please consider this carefully:

- Since _every_ property visit receives a `key`, the code will work properly if we decide to introduce new dictionaries. (For example, we've already changed multiple arrays to dictionaries, and the visitor would not have to change if we did that again.) BUT...
- Once the key has been set, all _nested_ object visits receive the key. For example, when we visit the `run.files` dictionary, the visit to each `file` object in the dictionary receives the key, which is good. But the visits to all of the `file` object's properties -- for example, `file.fileLocation` -- _also_ receive the key.

You could interpret this as meaning that `key` always denotes the key in the _nearest enclosing dictionary_. But it does mean that you can't tell the difference between an object that is directly a dictionary element, and one that is _a property of_ a dictionary element.

Fortunately, as the SARIF schema stands, there are no objects that can appear both as a dictionary element and as a property of a dictionary element. But it could happen.

I tested the new visitor by copying it to sarif-sdk, making the necessary changes to the derived visitor classes, and building and running all the tests. Everything passes. And debugging through the code I confirm that the dictionary element visits do indeed receive the desired key.