### PR TITLE
Fix #57, fix #58: Emit initializers and attributes for default values

### DIFF
--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -876,6 +876,15 @@ namespace N
       ""description"": ""An integer property with a default value."",
       ""default"": 42
     },
+    ""numberProp"": {
+      ""type"": ""number"",
+      ""description"": ""A number property.""
+    },
+    ""numberPropWithDefault"": {
+      ""type"": ""number"",
+      ""description"": ""A number property with a default value."",
+      ""default"": 42.1
+    },
     ""stringProp"": {
       ""type"": ""string"",
       ""description"": ""A string property.""
@@ -1062,6 +1071,18 @@ namespace N
         public int IntPropWithDefault { get; set; }
 
         /// <summary>
+        /// A number property.
+        /// </summary>
+        [DataMember(Name = ""numberProp"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProp { get; set; }
+
+        /// <summary>
+        /// A number property with a default value.
+        /// </summary>
+        [DataMember(Name = ""numberPropWithDefault"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberPropWithDefault { get; set; }
+
+        /// <summary>
         /// A string property.
         /// </summary>
         [DataMember(Name = ""stringProp"", IsRequired = false, EmitDefaultValue = false)]
@@ -1165,6 +1186,7 @@ namespace N
         public C()
         {
             IntPropWithDefault = 42;
+            NumberPropWithDefault = 42.1;
             StringPropWithDefault = ""42"";
             BoolPropWithTrueDefault = true;
             BoolPropWithFalseDefault = false;
@@ -1178,6 +1200,12 @@ namespace N
         /// </param>
         /// <param name=""intPropWithDefault"">
         /// An initialization value for the <see cref=""P: IntPropWithDefault"" /> property.
+        /// </param>
+        /// <param name=""numberProp"">
+        /// An initialization value for the <see cref=""P: NumberProp"" /> property.
+        /// </param>
+        /// <param name=""numberPropWithDefault"">
+        /// An initialization value for the <see cref=""P: NumberPropWithDefault"" /> property.
         /// </param>
         /// <param name=""stringProp"">
         /// An initialization value for the <see cref=""P: StringProp"" /> property.
@@ -1230,9 +1258,9 @@ namespace N
         /// <param name=""dictionaryWithHintedValueProp"">
         /// An initialization value for the <see cref=""P: DictionaryWithHintedValueProp"" /> property.
         /// </param>
-        public C(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, bool boolProp, bool boolPropWithTrueDefault, bool boolPropWithFalseDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        public C(int intProp, int intPropWithDefault, double numberProp, double numberPropWithDefault, string stringProp, string stringPropWithDefault, bool boolProp, bool boolPropWithTrueDefault, bool boolPropWithFalseDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
-            Init(intProp, intPropWithDefault, stringProp, stringPropWithDefault, boolProp, boolPropWithTrueDefault, boolPropWithFalseDefault, arrayProp, uriProp, dateTimeProp, referencedTypeProp, arrayOfRefProp, arrayOfArrayProp, dictionaryProp, dictionaryWithPrimitiveSchemaProp, dictionaryWithObjectSchemaProp, dictionaryWithObjectArraySchemaProp, dictionaryWithUriKeyProp, dictionaryWithHintedValueProp);
+            Init(intProp, intPropWithDefault, numberProp, numberPropWithDefault, stringProp, stringPropWithDefault, boolProp, boolPropWithTrueDefault, boolPropWithFalseDefault, arrayProp, uriProp, dateTimeProp, referencedTypeProp, arrayOfRefProp, arrayOfArrayProp, dictionaryProp, dictionaryWithPrimitiveSchemaProp, dictionaryWithObjectSchemaProp, dictionaryWithObjectArraySchemaProp, dictionaryWithUriKeyProp, dictionaryWithHintedValueProp);
         }
 
         /// <summary>
@@ -1251,7 +1279,7 @@ namespace N
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.IntProp, other.IntPropWithDefault, other.StringProp, other.StringPropWithDefault, other.BoolProp, other.BoolPropWithTrueDefault, other.BoolPropWithFalseDefault, other.ArrayProp, other.UriProp, other.DateTimeProp, other.ReferencedTypeProp, other.ArrayOfRefProp, other.ArrayOfArrayProp, other.DictionaryProp, other.DictionaryWithPrimitiveSchemaProp, other.DictionaryWithObjectSchemaProp, other.DictionaryWithObjectArraySchemaProp, other.DictionaryWithUriKeyProp, other.DictionaryWithHintedValueProp);
+            Init(other.IntProp, other.IntPropWithDefault, other.NumberProp, other.NumberPropWithDefault, other.StringProp, other.StringPropWithDefault, other.BoolProp, other.BoolPropWithTrueDefault, other.BoolPropWithFalseDefault, other.ArrayProp, other.UriProp, other.DateTimeProp, other.ReferencedTypeProp, other.ArrayOfRefProp, other.ArrayOfArrayProp, other.DictionaryProp, other.DictionaryWithPrimitiveSchemaProp, other.DictionaryWithObjectSchemaProp, other.DictionaryWithObjectArraySchemaProp, other.DictionaryWithUriKeyProp, other.DictionaryWithHintedValueProp);
         }
 
         ISNode ISNode.DeepClone()
@@ -1272,10 +1300,12 @@ namespace N
             return new C(this);
         }
 
-        private void Init(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, bool boolProp, bool boolPropWithTrueDefault, bool boolPropWithFalseDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        private void Init(int intProp, int intPropWithDefault, double numberProp, double numberPropWithDefault, string stringProp, string stringPropWithDefault, bool boolProp, bool boolPropWithTrueDefault, bool boolPropWithFalseDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
             IntProp = intProp;
             IntPropWithDefault = intPropWithDefault;
+            NumberProp = numberProp;
+            NumberPropWithDefault = numberPropWithDefault;
             StringProp = stringProp;
             StringPropWithDefault = stringPropWithDefault;
             BoolProp = boolProp;

--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -1039,6 +1039,7 @@ namespace N
 @"using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace N
@@ -1068,6 +1069,7 @@ namespace N
         /// An integer property with a default value.
         /// </summary>
         [DataMember(Name = ""intPropWithDefault"", IsRequired = false, EmitDefaultValue = false)]
+        [DefaultValue(42)]
         public int IntPropWithDefault { get; set; }
 
         /// <summary>
@@ -1080,6 +1082,7 @@ namespace N
         /// A number property with a default value.
         /// </summary>
         [DataMember(Name = ""numberPropWithDefault"", IsRequired = false, EmitDefaultValue = false)]
+        [DefaultValue(42.1)]
         public double NumberPropWithDefault { get; set; }
 
         /// <summary>
@@ -1092,6 +1095,7 @@ namespace N
         /// A string property with a default value.
         /// </summary>
         [DataMember(Name = ""stringPropWithDefault"", IsRequired = false, EmitDefaultValue = false)]
+        [DefaultValue(""42"")]
         public string StringPropWithDefault { get; set; }
 
         /// <summary>
@@ -1104,12 +1108,14 @@ namespace N
         /// A Boolean property with a true default value.
         /// </summary>
         [DataMember(Name = ""boolPropWithTrueDefault"", IsRequired = false, EmitDefaultValue = false)]
+        [DefaultValue(true)]
         public bool BoolPropWithTrueDefault { get; set; }
 
         /// <summary>
         /// A Boolean property with a false default value.
         /// </summary>
         [DataMember(Name = ""boolPropWithFalseDefault"", IsRequired = false, EmitDefaultValue = false)]
+        [DefaultValue(false)]
         public bool BoolPropWithFalseDefault { get; set; }
 
         /// <summary>
@@ -1196,67 +1202,67 @@ namespace N
         /// Initializes a new instance of the <see cref=""C"" /> class from the supplied values.
         /// </summary>
         /// <param name=""intProp"">
-        /// An initialization value for the <see cref=""P: IntProp"" /> property.
+        /// An initialization value for the <see cref=""P:IntProp"" /> property.
         /// </param>
         /// <param name=""intPropWithDefault"">
-        /// An initialization value for the <see cref=""P: IntPropWithDefault"" /> property.
+        /// An initialization value for the <see cref=""P:IntPropWithDefault"" /> property.
         /// </param>
         /// <param name=""numberProp"">
-        /// An initialization value for the <see cref=""P: NumberProp"" /> property.
+        /// An initialization value for the <see cref=""P:NumberProp"" /> property.
         /// </param>
         /// <param name=""numberPropWithDefault"">
-        /// An initialization value for the <see cref=""P: NumberPropWithDefault"" /> property.
+        /// An initialization value for the <see cref=""P:NumberPropWithDefault"" /> property.
         /// </param>
         /// <param name=""stringProp"">
-        /// An initialization value for the <see cref=""P: StringProp"" /> property.
+        /// An initialization value for the <see cref=""P:StringProp"" /> property.
         /// </param>
         /// <param name=""stringPropWithDefault"">
-        /// An initialization value for the <see cref=""P: StringPropWithDefault"" /> property.
+        /// An initialization value for the <see cref=""P:StringPropWithDefault"" /> property.
         /// </param>
         /// <param name=""boolProp"">
-        /// An initialization value for the <see cref=""P: BoolProp"" /> property.
+        /// An initialization value for the <see cref=""P:BoolProp"" /> property.
         /// </param>
         /// <param name=""boolPropWithTrueDefault"">
-        /// An initialization value for the <see cref=""P: BoolPropWithTrueDefault"" /> property.
+        /// An initialization value for the <see cref=""P:BoolPropWithTrueDefault"" /> property.
         /// </param>
         /// <param name=""boolPropWithFalseDefault"">
-        /// An initialization value for the <see cref=""P: BoolPropWithFalseDefault"" /> property.
+        /// An initialization value for the <see cref=""P:BoolPropWithFalseDefault"" /> property.
         /// </param>
         /// <param name=""arrayProp"">
-        /// An initialization value for the <see cref=""P: ArrayProp"" /> property.
+        /// An initialization value for the <see cref=""P:ArrayProp"" /> property.
         /// </param>
         /// <param name=""uriProp"">
-        /// An initialization value for the <see cref=""P: UriProp"" /> property.
+        /// An initialization value for the <see cref=""P:UriProp"" /> property.
         /// </param>
         /// <param name=""dateTimeProp"">
-        /// An initialization value for the <see cref=""P: DateTimeProp"" /> property.
+        /// An initialization value for the <see cref=""P:DateTimeProp"" /> property.
         /// </param>
         /// <param name=""referencedTypeProp"">
-        /// An initialization value for the <see cref=""P: ReferencedTypeProp"" /> property.
+        /// An initialization value for the <see cref=""P:ReferencedTypeProp"" /> property.
         /// </param>
         /// <param name=""arrayOfRefProp"">
-        /// An initialization value for the <see cref=""P: ArrayOfRefProp"" /> property.
+        /// An initialization value for the <see cref=""P:ArrayOfRefProp"" /> property.
         /// </param>
         /// <param name=""arrayOfArrayProp"">
-        /// An initialization value for the <see cref=""P: ArrayOfArrayProp"" /> property.
+        /// An initialization value for the <see cref=""P:ArrayOfArrayProp"" /> property.
         /// </param>
         /// <param name=""dictionaryProp"">
-        /// An initialization value for the <see cref=""P: DictionaryProp"" /> property.
+        /// An initialization value for the <see cref=""P:DictionaryProp"" /> property.
         /// </param>
         /// <param name=""dictionaryWithPrimitiveSchemaProp"">
-        /// An initialization value for the <see cref=""P: DictionaryWithPrimitiveSchemaProp"" /> property.
+        /// An initialization value for the <see cref=""P:DictionaryWithPrimitiveSchemaProp"" /> property.
         /// </param>
         /// <param name=""dictionaryWithObjectSchemaProp"">
-        /// An initialization value for the <see cref=""P: DictionaryWithObjectSchemaProp"" /> property.
+        /// An initialization value for the <see cref=""P:DictionaryWithObjectSchemaProp"" /> property.
         /// </param>
         /// <param name=""dictionaryWithObjectArraySchemaProp"">
-        /// An initialization value for the <see cref=""P: DictionaryWithObjectArraySchemaProp"" /> property.
+        /// An initialization value for the <see cref=""P:DictionaryWithObjectArraySchemaProp"" /> property.
         /// </param>
         /// <param name=""dictionaryWithUriKeyProp"">
-        /// An initialization value for the <see cref=""P: DictionaryWithUriKeyProp"" /> property.
+        /// An initialization value for the <see cref=""P:DictionaryWithUriKeyProp"" /> property.
         /// </param>
         /// <param name=""dictionaryWithHintedValueProp"">
-        /// An initialization value for the <see cref=""P: DictionaryWithHintedValueProp"" /> property.
+        /// An initialization value for the <see cref=""P:DictionaryWithHintedValueProp"" /> property.
         /// </param>
         public C(int intProp, int intPropWithDefault, double numberProp, double numberPropWithDefault, string stringProp, string stringPropWithDefault, bool boolProp, bool boolPropWithTrueDefault, bool boolPropWithFalseDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
@@ -2558,7 +2564,7 @@ namespace N
         /// Initializes a new instance of the <see cref=""C"" /> class from the supplied values.
         /// </summary>
         /// <param name=""uriFormattedStrings"">
-        /// An initialization value for the <see cref=""P: UriFormattedStrings"" /> property.
+        /// An initialization value for the <see cref=""P:UriFormattedStrings"" /> property.
         /// </param>
         public C(IEnumerable<Uri> uriFormattedStrings)
         {

--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -885,6 +885,20 @@ namespace N
       ""description"": ""A string property with a default value."",
       ""default"": ""42""
     },
+    ""boolProp"": {
+      ""type"": ""boolean"",
+      ""description"": ""A Boolean property.""
+    },
+    ""boolPropWithTrueDefault"": {
+      ""type"": ""boolean"",
+      ""description"": ""A Boolean property with a true default value."",
+      ""default"": true
+    },
+    ""boolPropWithFalseDefault"": {
+      ""type"": ""boolean"",
+      ""description"": ""A Boolean property with a false default value."",
+      ""default"": false
+    },
     ""arrayProp"": {
       ""type"": ""array"",
       ""description"": ""An array property."",
@@ -1060,6 +1074,24 @@ namespace N
         public string StringPropWithDefault { get; set; }
 
         /// <summary>
+        /// A Boolean property.
+        /// </summary>
+        [DataMember(Name = ""boolProp"", IsRequired = false, EmitDefaultValue = false)]
+        public bool BoolProp { get; set; }
+
+        /// <summary>
+        /// A Boolean property with a true default value.
+        /// </summary>
+        [DataMember(Name = ""boolPropWithTrueDefault"", IsRequired = false, EmitDefaultValue = false)]
+        public bool BoolPropWithTrueDefault { get; set; }
+
+        /// <summary>
+        /// A Boolean property with a false default value.
+        /// </summary>
+        [DataMember(Name = ""boolPropWithFalseDefault"", IsRequired = false, EmitDefaultValue = false)]
+        public bool BoolPropWithFalseDefault { get; set; }
+
+        /// <summary>
         /// An array property.
         /// </summary>
         [DataMember(Name = ""arrayProp"", IsRequired = false, EmitDefaultValue = false)]
@@ -1134,6 +1166,8 @@ namespace N
         {
             IntPropWithDefault = 42;
             StringPropWithDefault = ""42"";
+            BoolPropWithTrueDefault = true;
+            BoolPropWithFalseDefault = false;
         }
 
         /// <summary>
@@ -1150,6 +1184,15 @@ namespace N
         /// </param>
         /// <param name=""stringPropWithDefault"">
         /// An initialization value for the <see cref=""P: StringPropWithDefault"" /> property.
+        /// </param>
+        /// <param name=""boolProp"">
+        /// An initialization value for the <see cref=""P: BoolProp"" /> property.
+        /// </param>
+        /// <param name=""boolPropWithTrueDefault"">
+        /// An initialization value for the <see cref=""P: BoolPropWithTrueDefault"" /> property.
+        /// </param>
+        /// <param name=""boolPropWithFalseDefault"">
+        /// An initialization value for the <see cref=""P: BoolPropWithFalseDefault"" /> property.
         /// </param>
         /// <param name=""arrayProp"">
         /// An initialization value for the <see cref=""P: ArrayProp"" /> property.
@@ -1187,9 +1230,9 @@ namespace N
         /// <param name=""dictionaryWithHintedValueProp"">
         /// An initialization value for the <see cref=""P: DictionaryWithHintedValueProp"" /> property.
         /// </param>
-        public C(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        public C(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, bool boolProp, bool boolPropWithTrueDefault, bool boolPropWithFalseDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
-            Init(intProp, intPropWithDefault, stringProp, stringPropWithDefault, arrayProp, uriProp, dateTimeProp, referencedTypeProp, arrayOfRefProp, arrayOfArrayProp, dictionaryProp, dictionaryWithPrimitiveSchemaProp, dictionaryWithObjectSchemaProp, dictionaryWithObjectArraySchemaProp, dictionaryWithUriKeyProp, dictionaryWithHintedValueProp);
+            Init(intProp, intPropWithDefault, stringProp, stringPropWithDefault, boolProp, boolPropWithTrueDefault, boolPropWithFalseDefault, arrayProp, uriProp, dateTimeProp, referencedTypeProp, arrayOfRefProp, arrayOfArrayProp, dictionaryProp, dictionaryWithPrimitiveSchemaProp, dictionaryWithObjectSchemaProp, dictionaryWithObjectArraySchemaProp, dictionaryWithUriKeyProp, dictionaryWithHintedValueProp);
         }
 
         /// <summary>
@@ -1208,7 +1251,7 @@ namespace N
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.IntProp, other.IntPropWithDefault, other.StringProp, other.StringPropWithDefault, other.ArrayProp, other.UriProp, other.DateTimeProp, other.ReferencedTypeProp, other.ArrayOfRefProp, other.ArrayOfArrayProp, other.DictionaryProp, other.DictionaryWithPrimitiveSchemaProp, other.DictionaryWithObjectSchemaProp, other.DictionaryWithObjectArraySchemaProp, other.DictionaryWithUriKeyProp, other.DictionaryWithHintedValueProp);
+            Init(other.IntProp, other.IntPropWithDefault, other.StringProp, other.StringPropWithDefault, other.BoolProp, other.BoolPropWithTrueDefault, other.BoolPropWithFalseDefault, other.ArrayProp, other.UriProp, other.DateTimeProp, other.ReferencedTypeProp, other.ArrayOfRefProp, other.ArrayOfArrayProp, other.DictionaryProp, other.DictionaryWithPrimitiveSchemaProp, other.DictionaryWithObjectSchemaProp, other.DictionaryWithObjectArraySchemaProp, other.DictionaryWithUriKeyProp, other.DictionaryWithHintedValueProp);
         }
 
         ISNode ISNode.DeepClone()
@@ -1229,12 +1272,15 @@ namespace N
             return new C(this);
         }
 
-        private void Init(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        private void Init(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, bool boolProp, bool boolPropWithTrueDefault, bool boolPropWithFalseDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
             IntProp = intProp;
             IntPropWithDefault = intPropWithDefault;
             StringProp = stringProp;
             StringPropWithDefault = stringPropWithDefault;
+            BoolProp = boolProp;
+            BoolPropWithTrueDefault = boolPropWithTrueDefault;
+            BoolPropWithFalseDefault = boolPropWithFalseDefault;
             if (arrayProp != null)
             {
                 var destination_0 = new List<double>();

--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -871,9 +871,19 @@ namespace N
       ""type"": ""integer"",
       ""description"": ""An integer property.""
     },
+    ""intPropWithDefault"": {
+      ""type"": ""integer"",
+      ""description"": ""An integer property with a default value."",
+      ""default"": 42
+    },
     ""stringProp"": {
       ""type"": ""string"",
       ""description"": ""A string property.""
+    },
+    ""stringPropWithDefault"": {
+      ""type"": ""string"",
+      ""description"": ""A string property with a default value."",
+      ""default"": ""42""
     },
     ""arrayProp"": {
       ""type"": ""array"",
@@ -1032,10 +1042,22 @@ namespace N
         public int IntProp { get; set; }
 
         /// <summary>
+        /// An integer property with a default value.
+        /// </summary>
+        [DataMember(Name = ""intPropWithDefault"", IsRequired = false, EmitDefaultValue = false)]
+        public int IntPropWithDefault { get; set; }
+
+        /// <summary>
         /// A string property.
         /// </summary>
         [DataMember(Name = ""stringProp"", IsRequired = false, EmitDefaultValue = false)]
         public string StringProp { get; set; }
+
+        /// <summary>
+        /// A string property with a default value.
+        /// </summary>
+        [DataMember(Name = ""stringPropWithDefault"", IsRequired = false, EmitDefaultValue = false)]
+        public string StringPropWithDefault { get; set; }
 
         /// <summary>
         /// An array property.
@@ -1110,6 +1132,8 @@ namespace N
         /// </summary>
         public C()
         {
+            IntPropWithDefault = 42;
+            StringPropWithDefault = ""42"";
         }
 
         /// <summary>
@@ -1118,8 +1142,14 @@ namespace N
         /// <param name=""intProp"">
         /// An initialization value for the <see cref=""P: IntProp"" /> property.
         /// </param>
+        /// <param name=""intPropWithDefault"">
+        /// An initialization value for the <see cref=""P: IntPropWithDefault"" /> property.
+        /// </param>
         /// <param name=""stringProp"">
         /// An initialization value for the <see cref=""P: StringProp"" /> property.
+        /// </param>
+        /// <param name=""stringPropWithDefault"">
+        /// An initialization value for the <see cref=""P: StringPropWithDefault"" /> property.
         /// </param>
         /// <param name=""arrayProp"">
         /// An initialization value for the <see cref=""P: ArrayProp"" /> property.
@@ -1157,9 +1187,9 @@ namespace N
         /// <param name=""dictionaryWithHintedValueProp"">
         /// An initialization value for the <see cref=""P: DictionaryWithHintedValueProp"" /> property.
         /// </param>
-        public C(int intProp, string stringProp, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        public C(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
-            Init(intProp, stringProp, arrayProp, uriProp, dateTimeProp, referencedTypeProp, arrayOfRefProp, arrayOfArrayProp, dictionaryProp, dictionaryWithPrimitiveSchemaProp, dictionaryWithObjectSchemaProp, dictionaryWithObjectArraySchemaProp, dictionaryWithUriKeyProp, dictionaryWithHintedValueProp);
+            Init(intProp, intPropWithDefault, stringProp, stringPropWithDefault, arrayProp, uriProp, dateTimeProp, referencedTypeProp, arrayOfRefProp, arrayOfArrayProp, dictionaryProp, dictionaryWithPrimitiveSchemaProp, dictionaryWithObjectSchemaProp, dictionaryWithObjectArraySchemaProp, dictionaryWithUriKeyProp, dictionaryWithHintedValueProp);
         }
 
         /// <summary>
@@ -1178,7 +1208,7 @@ namespace N
                 throw new ArgumentNullException(nameof(other));
             }
 
-            Init(other.IntProp, other.StringProp, other.ArrayProp, other.UriProp, other.DateTimeProp, other.ReferencedTypeProp, other.ArrayOfRefProp, other.ArrayOfArrayProp, other.DictionaryProp, other.DictionaryWithPrimitiveSchemaProp, other.DictionaryWithObjectSchemaProp, other.DictionaryWithObjectArraySchemaProp, other.DictionaryWithUriKeyProp, other.DictionaryWithHintedValueProp);
+            Init(other.IntProp, other.IntPropWithDefault, other.StringProp, other.StringPropWithDefault, other.ArrayProp, other.UriProp, other.DateTimeProp, other.ReferencedTypeProp, other.ArrayOfRefProp, other.ArrayOfArrayProp, other.DictionaryProp, other.DictionaryWithPrimitiveSchemaProp, other.DictionaryWithObjectSchemaProp, other.DictionaryWithObjectArraySchemaProp, other.DictionaryWithUriKeyProp, other.DictionaryWithHintedValueProp);
         }
 
         ISNode ISNode.DeepClone()
@@ -1199,10 +1229,12 @@ namespace N
             return new C(this);
         }
 
-        private void Init(int intProp, string stringProp, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        private void Init(int intProp, int intPropWithDefault, string stringProp, string stringPropWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
             IntProp = intProp;
+            IntPropWithDefault = intPropWithDefault;
             StringProp = stringProp;
+            StringPropWithDefault = stringPropWithDefault;
             if (arrayProp != null)
             {
                 var destination_0 = new List<double>();

--- a/src/Json.Schema.ToDotNet/ClassGenerator.cs
+++ b/src/Json.Schema.ToDotNet/ClassGenerator.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                     ExpressionStatementSyntax initializationStatement = GenerateDefaultInitialization(propertyName, defaultValue);
                     if (initializationStatement != null)
                     {
-                        initializations.Add(GenerateDefaultInitialization(propertyName, defaultValue));
+                        initializations.Add(initializationStatement);
                     }
                 }
             }

--- a/src/Json.Schema.ToDotNet/ClassGenerator.cs
+++ b/src/Json.Schema.ToDotNet/ClassGenerator.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Json.Schema.ToDotNet
         // Name used for the parameters of the copy ctor.
         private const string OtherParameterName = "other";
 
+        private const string DefaultValueAttributeNamespaceName = "System.ComponentModel";
+        private const string DefaultValueAttributeName = "DefaultValue";
+
         private const string DataContractAttributeName = "DataContract";
         private const string DataMemberAttributeName = "DataMember";
         private const string DataMemberNamePropertyName = "Name";
@@ -241,7 +244,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
         }
 
-        protected override AttributeSyntax[] GeneratePropertyAttributes(string propertyName, string serializedName, bool isRequired)
+        protected override AttributeSyntax[] GeneratePropertyAttributes(string propertyName, string serializedName, bool isRequired, object defaultValue)
         {
             var attributes = new List<AttributeSyntax>();
 
@@ -278,6 +281,24 @@ namespace Microsoft.Json.Schema.ToDotNet
                         SyntaxFactory.SeparatedList(dataMemberAttributeArguments)));
 
             attributes.Add(dataMemberAttribute);
+
+            if (defaultValue != null)
+            {
+                AddUsing(DefaultValueAttributeNamespaceName);
+
+                var defaultValueArguments = new List<AttributeArgumentSyntax>
+                {
+                    SyntaxFactory.AttributeArgument(GetLiteralExpressionForValue(defaultValue))
+                };
+
+                AttributeSyntax defaultValueAttribute =
+                    SyntaxFactory.Attribute(
+                        SyntaxFactory.IdentifierName(DefaultValueAttributeName),
+                        SyntaxFactory.AttributeArgumentList(
+                            SyntaxFactory.SeparatedList(defaultValueArguments)));
+
+                attributes.Add(defaultValueAttribute);
+            }
 
             string hintDictionaryKey = MakeHintDictionaryKey(propertyName);
             AttributeHint[] attributeHints = HintDictionary?.GetHints<AttributeHint>(hintDictionaryKey);

--- a/src/Json.Schema.ToDotNet/ClassGenerator.cs
+++ b/src/Json.Schema.ToDotNet/ClassGenerator.cs
@@ -442,23 +442,17 @@ namespace Microsoft.Json.Schema.ToDotNet
 
                 literalExpression = SyntaxFactory.LiteralExpression(literalSyntaxKind);
             }
-            else if (value is int)
-            {
-                literalExpression = SyntaxFactory.LiteralExpression(
-                    SyntaxKind.NumericLiteralExpression,
-                    SyntaxFactory.Literal((int)value));
-            }
             else if (value is long)
             {
                 literalExpression = SyntaxFactory.LiteralExpression(
                     SyntaxKind.NumericLiteralExpression,
                     SyntaxFactory.Literal((int)(long)value));
-            }
-            else if (value is float)
-            {
-                literalExpression = SyntaxFactory.LiteralExpression(
-                    SyntaxKind.NumericLiteralExpression,
-                    SyntaxFactory.Literal((float)value));
+                // Note: the extra cast compensates for a mismatch between our code generation
+                // and Newtonsoft.Json's deserialization behavior. Newtonsoft deserializes
+                // integer properties as Int64 (long), but we generate integer properties
+                // with type int. The extra cast causes Roslyn to emit the literal 42,
+                // which can be assigned to an int, rather than 42L, which cannot. We should
+                // consider changing the code generation to emit longs for integer properties.
             }
             else if (value is double)
             {

--- a/src/Json.Schema.ToDotNet/ClassGenerator.cs
+++ b/src/Json.Schema.ToDotNet/ClassGenerator.cs
@@ -372,13 +372,31 @@ namespace Microsoft.Json.Schema.ToDotNet
         {
             return SyntaxFactory.ConstructorDeclaration(SuffixedTypeName)
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
-                .AddBodyStatements()
+                .AddBodyStatements(GenerateDefaultInitializations())
                 .WithLeadingTrivia(
                     SyntaxHelper.MakeDocComment(
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Resources.DefaultCtorSummary,
                             SuffixedTypeName)));
+        }
+
+        /// <summary>
+        /// Generates an initialization statement for each property for which the
+        /// schema specifies a default value.
+        /// </summary>
+        /// <remarks>
+        /// The resulting statements are inserted into the default constructor.
+        /// This ensures that the default values are set even if the object is
+        /// not the result of deserializing a JSON instance document.
+        /// <remarks>
+        /// <returns>
+        /// An array containing one initialization statement for each property
+        /// for which the schema specifies a default value.
+        /// </returns>
+        private StatementSyntax[] GenerateDefaultInitializations()
+        {
+            return new StatementSyntax[0];
         }
 
         private ConstructorDeclarationSyntax GeneratePropertyCtor()

--- a/src/Json.Schema.ToDotNet/ClassOrInterfaceGenerator.cs
+++ b/src/Json.Schema.ToDotNet/ClassOrInterfaceGenerator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Json.Schema.ToDotNet
             PropInfoDictionary = propertyInfoDictionary;
         }
 
-        protected abstract AttributeSyntax[] GeneratePropertyAttributes(string propertyName, string serializedName, bool isRequired);
+        protected abstract AttributeSyntax[] GeneratePropertyAttributes(string propertyName, string serializedName, bool isRequired, object defaultValue);
 
         protected abstract SyntaxToken[] GeneratePropertyModifiers(string propertyName);
 
@@ -103,7 +103,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                 .AddModifiers(GeneratePropertyModifiers(propertyName))
                 .AddAccessorListAccessors(GeneratePropertyAccessors());
 
-            AttributeSyntax[] attributes = GeneratePropertyAttributes(propertyName, info.SerializedName, info.IsRequired);
+            AttributeSyntax[] attributes = GeneratePropertyAttributes(propertyName, info.SerializedName, info.IsRequired, info.DefaultValue);
             if (attributes.Length > 0)
             {
                 propDecl = propDecl.AddAttributeLists(attributes

--- a/src/Json.Schema.ToDotNet/EqualityComparerGenerator.cs
+++ b/src/Json.Schema.ToDotNet/EqualityComparerGenerator.cs
@@ -111,16 +111,20 @@ namespace Microsoft.Json.Schema.ToDotNet
                         GenerateEqualsMethod(),
                         GenerateGetHashCodeMethod());
 
-            var usings = new List<string>
+            var usings = new HashSet<string>
             {
                 "System",                       // For Object.
                 "System.Collections.Generic"    // For IEqualityComparer<T>
             };
 
-            usings.AddRange(_propertyInfoDictionary
+            IEnumerable<string> namespaceNames = _propertyInfoDictionary
                 .Values
                 .Select(propertyInfo => propertyInfo.NamespaceName)
-                .Where(namespaceName => !string.IsNullOrWhiteSpace(namespaceName)));
+                .Where(namespaceName => !string.IsNullOrWhiteSpace(namespaceName));
+            foreach (string namespaceName in namespaceNames)
+            {
+                usings.Add(namespaceName);
+            }
 
             return classDeclaration.Format(
                 _copyrightNotice,

--- a/src/Json.Schema.ToDotNet/InterfaceGenerator.cs
+++ b/src/Json.Schema.ToDotNet/InterfaceGenerator.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                 .AddMembers(GenerateProperties());
         }
 
-        protected override AttributeSyntax[] GeneratePropertyAttributes(string propertyName, string serializedName, bool isRequired)
+        protected override AttributeSyntax[] GeneratePropertyAttributes(string propertyName, string serializedName, bool isRequired, object defaultValue)
         {
             return new AttributeSyntax[0];
         }

--- a/src/Json.Schema.ToDotNet/Json.Schema.ToDotNet.csproj
+++ b/src/Json.Schema.ToDotNet/Json.Schema.ToDotNet.csproj
@@ -17,6 +17,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Json.Schema\Json.Schema.csproj" />
   </ItemGroup>
 

--- a/src/Json.Schema.ToDotNet/PropertyInfo.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfo.cs
@@ -42,6 +42,9 @@ namespace Microsoft.Json.Schema.ToDotNet
         /// <code>true</code> if this property is required by the schema;
         /// otherwise <code>false</code>.
         /// </param>
+        /// <param name="defaultValue">
+        /// The default value, if any, specified by the schema; otherwise <code>null</code>.
+        /// </param>
         /// <param name="isOfSchemaDefinedType">
         /// <code>true</code> if this property is of a type defined by the schema (or an;
         /// array of a schema-defined type otherwise <code>false</code>.
@@ -61,6 +64,7 @@ namespace Microsoft.Json.Schema.ToDotNet
             TypeSyntax type,
             string namespaceName,
             bool isRequired,
+            object defaultValue,
             bool isOfSchemaDefinedType,
             int arrayRank,
             int declarationOrder)
@@ -74,6 +78,7 @@ namespace Microsoft.Json.Schema.ToDotNet
             TypeName = type.ToString();
             NamespaceName = namespaceName;
             IsRequired = isRequired;
+            DefaultValue = defaultValue;
             IsOfSchemaDefinedType = isOfSchemaDefinedType;
             ArrayRank = arrayRank;
             DeclarationOrder = declarationOrder;
@@ -130,6 +135,11 @@ namespace Microsoft.Json.Schema.ToDotNet
         /// Gets a value indicating whether this property is required by the schema.
         /// </summary>
         public bool IsRequired { get; }
+
+        /// <summary>
+        /// Gets this property's default value, if the schema specifies one; otherwise <code>null</code>.
+        /// </summary>
+        public object DefaultValue;
 
         /// <summary>
         /// Gets a value indicating whether this property is of a type defined by the schema.

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -56,8 +56,8 @@ namespace Microsoft.Json.Schema.ToDotNet
         /// </remarks>
         public delegate void AdditionalTypeRequiredDelegate(AdditionalTypeRequiredInfo additionalTypeRequiredInfo);
 
-        private AdditionalTypeRequiredDelegate _additionalTypeRequiredDelegate;
-        private string _typeNameSuffix;
+        private readonly AdditionalTypeRequiredDelegate _additionalTypeRequiredDelegate;
+        private readonly string _typeNameSuffix;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyInfoDictionary"/> class.
@@ -142,8 +142,7 @@ namespace Microsoft.Json.Schema.ToDotNet
 
         public static SyntaxKind GetTypeKeywordFromSchemaType(SchemaType type)
         {
-            SyntaxKind typeKeyword;
-            if (!s_SchemaTypeToSyntaxKindDictionary.TryGetValue(type, out typeKeyword))
+            if (!s_SchemaTypeToSyntaxKindDictionary.TryGetValue(type, out SyntaxKind typeKeyword))
             {
                 typeKeyword = SyntaxKind.ObjectKeyword;
             }
@@ -157,8 +156,7 @@ namespace Microsoft.Json.Schema.ToDotNet
         {
             get
             {
-                PropertyInfo info;
-                if (!TryGetValue(key, out info))
+                if (!TryGetValue(key, out PropertyInfo info))
                 {
                     throw new ApplicationException($"The schema does not contain information describing the property or element {key}.");
                 }
@@ -228,8 +226,6 @@ namespace Microsoft.Json.Schema.ToDotNet
             string referencedEnumTypeName;
             bool isOfSchemaDefinedType = false;
             int arrayRank = 0;
-            EnumHint enumHint;
-            DictionaryHint dictionaryHint;
 
             if (propertySchema.IsDateTime())
             {
@@ -245,7 +241,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                 initializationKind = InitializationKind.Uri;
                 type = MakeNamedType("System.Uri", out namespaceName);
             }
-            else if (propertySchema.ShouldBeDictionary(_typeName, schemaPropertyName, _hintDictionary, out dictionaryHint))
+            else if (propertySchema.ShouldBeDictionary(_typeName, schemaPropertyName, _hintDictionary, out DictionaryHint dictionaryHint))
             {
                 comparisonKind = ComparisonKind.Dictionary;
                 hashKind = HashKind.Dictionary;
@@ -270,7 +266,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                 initializationKind = InitializationKind.SimpleAssign;
                 type = MakeNamedType(referencedEnumTypeName, out namespaceName);
             }
-            else if (propertySchema.ShouldBeEnum(_typeName, schemaPropertyName,  _hintDictionary, out enumHint))
+            else if (propertySchema.ShouldBeEnum(_typeName, schemaPropertyName,  _hintDictionary, out EnumHint enumHint))
             {
                 comparisonKind = ComparisonKind.OperatorEquals;
                 hashKind = HashKind.ScalarValueType;

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -10,7 +10,6 @@ using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Json.Schema.ToDotNet.Hints;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Json.Schema.ToDotNet
 {
@@ -284,7 +283,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                 OnAdditionalTypeRequired(enumHint, propertySchema);
             }
             else
-        	{
+            {
                 SchemaType propertyType = propertySchema.SafeGetType();
 
                 switch (propertyType)
@@ -384,6 +383,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                     type,
                     namespaceName,
                     isRequired,
+                    propertySchema.Default,
                     isOfSchemaDefinedType,
                     arrayRank,
                     entries.Count)));
@@ -477,6 +477,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                         type: valueType,
                         namespaceName: dictionaryHint.NamespaceName,
                         isRequired: true,
+                        defaultValue: null,
                         isOfSchemaDefinedType: false,
                         arrayRank: 0,
                         declarationOrder: 0)));

--- a/src/Json.Schema.ToDotNet/Resources.Designer.cs
+++ b/src/Json.Schema.ToDotNet/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Json.Schema.ToDotNet {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -214,7 +214,7 @@ namespace Microsoft.Json.Schema.ToDotNet {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An initialization value for the &lt;see cref=&quot;P: {0}&quot; /&gt; property..
+        ///   Looks up a localized string similar to An initialization value for the &lt;see cref=&quot;P:{0}&quot; /&gt; property..
         /// </summary>
         internal static string PropertyCtorParamDescription {
             get {

--- a/src/Json.Schema.ToDotNet/Resources.resx
+++ b/src/Json.Schema.ToDotNet/Resources.resx
@@ -169,7 +169,7 @@
     <value>An uninitialized kind.</value>
   </data>
   <data name="PropertyCtorParamDescription" xml:space="preserve">
-    <value>An initialization value for the &lt;see cref="P: {0}" /&gt; property.</value>
+    <value>An initialization value for the &lt;see cref="P:{0}" /&gt; property.</value>
   </data>
   <data name="PropertyCtorSummary" xml:space="preserve">
     <value>Initializes a new instance of the &lt;see cref="{0}" /&gt; class from the supplied values.</value>

--- a/src/Json.Schema.ToDotNet/RewritingVisitorGenerator.cs
+++ b/src/Json.Schema.ToDotNet/RewritingVisitorGenerator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                     .AddMembers(
                         GenerateVisitClassMethods());
 
-            var usings = new List<string> { "System", "System.Collections.Generic", "System.Linq" };
+            var usings = new HashSet<string> { "System", "System.Collections.Generic", "System.Linq" };
 
             string summaryComment = string.Format(
                 CultureInfo.CurrentCulture,
@@ -356,9 +356,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                     continue;
                 }
 
-                int arrayRank = 0;
-                bool isDictionary = false;
-                string propertyName = propertyNameWithRank.BasePropertyName(out arrayRank, out isDictionary);
+                string propertyName = propertyNameWithRank.BasePropertyName(out int arrayRank, out bool isDictionary);
 
                 TypeSyntax collectionType = propertyInfoDictionary.GetConcreteListType(propertyName);
                 TypeSyntax elementType = propertyInfoDictionary[propertyNameWithRank].Type;

--- a/src/Json.Schema.ToDotNet/SyntaxNodeExtensions.cs
+++ b/src/Json.Schema.ToDotNet/SyntaxNodeExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Json.Schema.ToDotNet
         internal static string Format(
             this BaseTypeDeclarationSyntax typeDecl,
             string copyrightNotice,
-            List<string> usings,
+            HashSet<string> usings,
             string namespaceName,
             string summaryComment)
         {
@@ -74,15 +74,11 @@ namespace Microsoft.Json.Schema.ToDotNet
             CompilationUnitSyntax compilationUnit = SyntaxFactory.CompilationUnit()
                 .AddMembers(namespaceDecl);
 
-            if (usings == null)
-            {
-                usings = new List<string>();
-            }
+            usings = usings ?? new HashSet<string>();
 
             usings.Add("System.CodeDom.Compiler"); // For GeneratedCodeAttribute
 
             UsingDirectiveSyntax[] usingDirectives = usings
-                .Distinct()
                 .OrderBy(u => u, UsingComparer.Instance)
                 .Select(u => SyntaxFactory.UsingDirective(MakeQualifiedName(u)))
                 .ToArray();

--- a/src/Json.Schema.ToDotNet/TypeGenerator.cs
+++ b/src/Json.Schema.ToDotNet/TypeGenerator.cs
@@ -75,10 +75,7 @@ namespace Microsoft.Json.Schema.ToDotNet
         {
             Usings = Usings ?? new List<string>();
 
-            if (!Usings.Contains(namespaceName))
-            {
-                Usings.Add(namespaceName);
-            }
+            Usings.Add(namespaceName);
         }
     }
 }

--- a/src/Json.Schema.ToDotNet/TypeGenerator.cs
+++ b/src/Json.Schema.ToDotNet/TypeGenerator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Json.Schema.ToDotNet
 {
     public abstract class TypeGenerator
     {
-        private string _typeNameSuffix;
+        private readonly string _typeNameSuffix;
 
         protected TypeGenerator(
             JsonSchema schema,
@@ -73,12 +73,12 @@ namespace Microsoft.Json.Schema.ToDotNet
 
         protected void AddUsing(string namespaceName)
         {
-            if (Usings == null)
-            {
-                Usings = new List<string>();
-            }
+            Usings = Usings ?? new List<string>();
 
-            Usings.Add(namespaceName);
+            if (!Usings.Contains(namespaceName))
+            {
+                Usings.Add(namespaceName);
+            }
         }
     }
 }

--- a/src/Json.Schema.ToDotNet/TypeGenerator.cs
+++ b/src/Json.Schema.ToDotNet/TypeGenerator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Json.Schema.ToDotNet
         /// </summary>
         protected BaseTypeDeclarationSyntax TypeDeclaration { get; set; }
 
-        protected List<string> Usings { get; private set; }
+        protected HashSet<string> Usings { get; private set; }
 
         public abstract BaseTypeDeclarationSyntax GenerateTypeDeclaration();
 
@@ -73,7 +73,7 @@ namespace Microsoft.Json.Schema.ToDotNet
 
         protected void AddUsing(string namespaceName)
         {
-            Usings = Usings ?? new List<string>();
+            Usings = Usings ?? new HashSet<string>();
 
             Usings.Add(namespaceName);
         }

--- a/src/Json.Schema.UnitTests/JsonSchemaTests.cs
+++ b/src/Json.Schema.UnitTests/JsonSchemaTests.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Json.Schema.UnitTests
                     ""uniqueItems"": true,
                     ""format"": ""date-time"",
                     ""maximimum"": 2,
-                    ""exclusiveMaximum"": false
+                    ""exclusiveMaximum"": false,
+                    ""default"": 2,
                 }",
                 @"{
                     ""id"": ""http://x/y#"",
@@ -128,7 +129,8 @@ namespace Microsoft.Json.Schema.UnitTests
                     ""uniqueItems"": true,
                     ""format"": ""date-time"",
                     ""maximimum"": 2,
-                    ""exclusiveMaximum"": false
+                    ""exclusiveMaximum"": false,
+                    ""default"": 2
                 }",
                 true
             ),
@@ -773,6 +775,84 @@ namespace Microsoft.Json.Schema.UnitTests
                 }",
                 false
             ),
+
+            new EqualityTestCase(
+                "Same integer defaults",
+                @"{
+                    ""default"": 2
+                }",
+                @"{
+                    ""default"": 2
+                }",
+                true),
+
+            new EqualityTestCase(
+                "Different integer defaults",
+                @"{
+                    ""default"": 2
+                }",
+                @"{
+                    ""default"": 3
+                }",
+                false),
+
+            new EqualityTestCase(
+                "Same string defaults",
+                @"{
+                    ""default"": ""2""
+                }",
+                @"{
+                    ""default"": ""2""
+                }",
+                true),
+
+            new EqualityTestCase(
+                "Different string defaults",
+                @"{
+                    ""default"": ""2""
+                }",
+                @"{
+                    ""default"": ""3""
+                }",
+                false),
+
+            new EqualityTestCase(
+                "Same Boolean defaults",
+                @"{
+                    ""default"": true
+                }",
+                @"{
+                    ""default"": true
+                }",
+                true),
+
+            new EqualityTestCase(
+                "Different Boolean defaults",
+                @"{
+                    ""default"": false
+                }",
+                @"{
+                    ""default"": true
+                }",
+                false),
+
+            new EqualityTestCase(
+                "Different default types",
+                @"{
+                    ""default"": 2
+                }",
+                @"{
+                    ""default"": ""2""
+                }",
+                false),
+
+            new EqualityTestCase(
+                "Present and missing defaults",
+                @"{
+                    ""default"": 2
+                }",
+                @"{}",
+                false)
         };
 
         [Theory(DisplayName = "JsonSchema equality")]

--- a/src/Json.Schema/JsonSchema.cs
+++ b/src/Json.Schema/JsonSchema.cs
@@ -527,8 +527,7 @@ namespace Microsoft.Json.Schema
 
                 string definitionName = schema.Reference.GetDefinitionName();
 
-                JsonSchema referencedSchema;
-                if (rootSchema.Definitions == null || !rootSchema.Definitions.TryGetValue(definitionName, out referencedSchema))
+                if (rootSchema.Definitions == null || !rootSchema.Definitions.TryGetValue(definitionName, out JsonSchema referencedSchema))
                 {
                     throw Error.CreateException(
                         Resources.ErrorDefinitionDoesNotExist,
@@ -619,7 +618,7 @@ namespace Microsoft.Json.Schema
 
         public bool Equals(JsonSchema other)
         {
-            if ((object)other == null)
+            if (other is null)
             {
                 return false;
             }
@@ -655,7 +654,7 @@ namespace Microsoft.Json.Schema
                 && (Reference == null
                         ? other.Reference == null
                         : Reference.Equals(other.Reference))
-                && DefaultsAreEqual(Default, other.Default)
+                && Object.Equals(Default, other.Default)
                 && Pattern == other.Pattern
                 && MaxLength == other.MaxLength
                 && MinLength == other.MinLength
@@ -689,7 +688,7 @@ namespace Microsoft.Json.Schema
                 return true;
             }
 
-            if ((object)left == null)
+            if (left is null)
             {
                 return false;
             }
@@ -700,26 +699,6 @@ namespace Microsoft.Json.Schema
         public static bool operator !=(JsonSchema left, JsonSchema right)
         {
             return !(left == right);
-        }
-
-        private static bool DefaultsAreEqual(object left, object right)
-        {
-            if ((left == null) != (right == null)) { return false; }
-
-            if (left == null) { return true; }
-
-            Type leftType = left.GetType(),
-                 rightType = right.GetType();
-            if (leftType != rightType) { return false; }
-
-            string leftString = left as String;
-            if (leftString != null) { return leftString.Equals(right as string, StringComparison.Ordinal); }
-
-            if (left is bool) { return (bool)left == (bool)right; }
-            if (left is long) { return (long)left == (long)right; }
-            if (left is double) { return (double)left == (double)right; }
-
-            return left == right; // Not good. How do we deal with other types?
         }
     }
 }

--- a/src/Json.Schema/JsonSchema.cs
+++ b/src/Json.Schema/JsonSchema.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Json.Schema
                 PatternProperties = new Dictionary<string, JsonSchema>(other.PatternProperties);
             }
 
+            Default = other.Default;
             Pattern = other.Pattern;
             MaxLength = other.MaxLength;
             MinLength = other.MinLength;
@@ -265,6 +266,12 @@ namespace Microsoft.Json.Schema
         /// This property applies only to schemas whose <see cref="Type"/> is <see cref="SchemaType.String"/>.
         /// </remarks>
         public int? MinLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value the property should be taken to have if it is absent
+        /// from an instance document.
+        /// </summary>
+        public object Default { get; set; }
 
         /// <summary>
         /// Gets or sets a regular expression which a string schema instance must match.
@@ -547,6 +554,7 @@ namespace Microsoft.Json.Schema
                     collapsedSchema.Items.SingleSchema = referencedSchema.Items.SingleSchema;
                 }
 
+                collapsedSchema.Default = referencedSchema.Default;
                 collapsedSchema.Pattern = referencedSchema.Pattern;
                 collapsedSchema.MaxLength = referencedSchema.MaxLength;
                 collapsedSchema.MinLength = referencedSchema.MinLength;
@@ -583,6 +591,7 @@ namespace Microsoft.Json.Schema
                 Required,
                 Definitions,
                 Reference,
+                Default,
                 Pattern,
                 MaxLength,
                 MinLength,
@@ -646,6 +655,7 @@ namespace Microsoft.Json.Schema
                 && (Reference == null
                         ? other.Reference == null
                         : Reference.Equals(other.Reference))
+                && DefaultsAreEqual(Default, other.Default)
                 && Pattern == other.Pattern
                 && MaxLength == other.MaxLength
                 && MinLength == other.MinLength
@@ -690,6 +700,26 @@ namespace Microsoft.Json.Schema
         public static bool operator !=(JsonSchema left, JsonSchema right)
         {
             return !(left == right);
+        }
+
+        private static bool DefaultsAreEqual(object left, object right)
+        {
+            if ((left == null) != (right == null)) { return false; }
+
+            if (left == null) { return true; }
+
+            Type leftType = left.GetType(),
+                 rightType = right.GetType();
+            if (leftType != rightType) { return false; }
+
+            string leftString = left as String;
+            if (leftString != null) { return leftString.Equals(right as string, StringComparison.Ordinal); }
+
+            if (left is bool) { return (bool)left == (bool)right; }
+            if (left is long) { return (long)left == (long)right; }
+            if (left is double) { return (double)left == (double)right; }
+
+            return left == right; // Not good. How do we deal with other types?
         }
     }
 }


### PR DESCRIPTION
#57: When a schema property declares a default value, assign that value to the property in the default constructor. This ensures that the property has the correct default even if you construct the object by hand rather than by deserializing it from JSON.

#58: When a schema property declares a default value, decorate the property with a `System.ComponentModel.DefaultValue` attribute. This avoids your having to specify those attributes in the CodeGenHints.json file, which is error-prone.

Also:
- Fix a bug where the generated doc comments for properties had an extra space: `cref="P: propName`" &rarr; `cref="P:propName`".
- Address some hygiene-related IDE messages by marking some properties `readonly`, and by inlining the declarations of some `out` parameters.