### PR TITLE
Update licensing reference to satisfy NuGet improvements in this area.

### DIFF
--- a/src/build.props
+++ b/src/build.props
@@ -36,7 +36,7 @@
     <Authors Condition=" '$(Authors)' == '' ">$(Company)</Authors>
     <Owners Condition=" '$(Authors)' == '' ">$(Company),tse-securitytools</Owners>
     <PackageRequireLicenseAcceptance Condition=" '$(PackageRequireLicenseAcceptance)' == '' ">false</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://github.com/Microsoft/jschema/blob/master/License.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Microsoft/jschema</PackageProjectUrl>
     <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=2009431</PackageIconUrl>
   </PropertyGroup>


### PR DESCRIPTION
@lgolding 

NuGet now allows referencing fixed license versions. These can be shipped in the package itself. NuGet packaging tools also have built-in understanding of standard licenses, such as the MIT license. Using PackageLicenseExpression to refer to MIT produces a new nuspec <license> element. NuGet packaging tools also provides a licenseUrl that points to the official hosted version of this license.

This change is required to submit to NuGet for Microsoft packages.