### PR TITLE
Fix #68, fix #69: Use packageLicenseExpression in all packages, and fix some package properties

### DIFF
--- a/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
+++ b/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
@@ -4,13 +4,13 @@
     <id>Microsoft.Json.Schema.ToDotNet</id>
     <version>$version$</version>
     <title>Microsoft JSON Schema to .NET Object Model Generator</title>
-    <authors>microsoft</authors>
-    <owners>microsoft,tse-securitytools</owners>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,tse-securitytools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A command line tool that generates a .NET object model from a JSON schema.</description>
     <releaseNotes>Version $version$ of the JSON .NET object model generator</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <licenseUrl>https://github.com/Microsoft/jschema/blob/master/LICENSE</licenseUrl>
+    <license type="expression">$packageLicenseExpression$</license>
     <projectUrl>https://github.com/microsoft/jschema</projectUrl>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=2009431</iconUrl>
     <tags>Microsoft JSON Schema .NET ToDotNet Object Model Generator Jschema</tags>

--- a/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
+++ b/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Json.Schema.ToDotNet</id>
     <version>$version$</version>
     <title>Microsoft JSON Schema to .NET Object Model Generator</title>
-    <authors>Microsoft</authors>
+    <authors>Microsoft,tse-securitytools</authors>
     <owners>Microsoft,tse-securitytools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A command line tool that generates a .NET object model from a JSON schema.</description>

--- a/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
+++ b/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.Json.Schema.Validation</id>
     <version>$version$</version>
     <title>Microsoft JSON Schema Validation</title>
-    <authors>Microsoft</authors>
+    <authors>Microsoft,tse-securitytools</authors>
     <owners>Microsoft,tse-securitytools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A command line tool that validates files against a JSON schema.</description>

--- a/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
+++ b/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
@@ -4,16 +4,16 @@
     <id>Microsoft.Json.Schema.Validation</id>
     <version>$version$</version>
     <title>Microsoft JSON Schema Validation</title>
-    <authors>microsoft</authors>
-    <owners>microsoft,tse-securitytools</owners>
+    <authors>Microsoft</authors>
+    <owners>Microsoft,tse-securitytools</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A command line tool that validates files against a JSON schema.</description>
     <releaseNotes>Version $version$ of the JSON validation tool.</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <licenseUrl>https://github.com/Microsoft/jschema/blob/master/LICENSE</licenseUrl>
+    <license type="expression">$packageLicenseExpression$</license>
     <projectUrl>https://github.com/microsoft/jschema</projectUrl>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=2009431</iconUrl>
-    <tags>Microsoft Json Schema .NET Validation Validator JSchema</tags>
+    <tags>Microsoft JSON Schema .NET Validation Validator JSchema</tags>
   </metadata>
   <files>
     <file src="bld\bin\$platform$_$configuration$\Json.Schema.Validation\net461\Microsoft.Json.Schema.Validation.dll"

--- a/src/build.props
+++ b/src/build.props
@@ -33,8 +33,9 @@
 
   <PropertyGroup Label="Package">
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
+    <Title Condition=" '$(Title)' == '' ">$(AssemblyTitle)</Title>
     <Authors Condition=" '$(Authors)' == '' ">$(Company)</Authors>
-    <Owners Condition=" '$(Authors)' == '' ">$(Company),tse-securitytools</Owners>
+    <Owners Condition=" '$(Owners)' == '' ">$(Company),tse-securitytools</Owners>
     <PackageRequireLicenseAcceptance Condition=" '$(PackageRequireLicenseAcceptance)' == '' ">false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Microsoft/jschema</PackageProjectUrl>

--- a/src/build.props
+++ b/src/build.props
@@ -34,8 +34,8 @@
   <PropertyGroup Label="Package">
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <Title Condition=" '$(Title)' == '' ">$(AssemblyTitle)</Title>
-    <Authors Condition=" '$(Authors)' == '' ">$(Company)</Authors>
-    <Owners Condition=" '$(Owners)' == '' ">$(Company),tse-securitytools</Owners>
+    <Authors Condition=" '$(Authors)' == '' ">$(Company),tse-securitytools</Authors>
+    <Owners Condition=" '$(Owners)' == '' ">$(Authors)</Owners>
     <PackageRequireLicenseAcceptance Condition=" '$(PackageRequireLicenseAcceptance)' == '' ">false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Microsoft/jschema</PackageProjectUrl>


### PR DESCRIPTION
This change fixes a problem with certain jschema packages which prevented them from being published, because they violated Microsoft package publishing policy (PPP, if you like ;-)). Opportunistically, it fixes a couple of other package property problems (PPP2, if you like).

Our build.props file sets the `<PackageLicenseExpression>` property to `Apache-2.0`. The creation of the JsonPointer and JsonSchema NuGet packages is done by `dotnet pack`, and is driven by the MSBuild project file. So those packages respected the package license expression, and picked up the correct license.

But the NuGet packages for the two command line tools (ToDotNet and Validator) are created by directly invoking NuGet.exe on custom .nuspec files. This is necessary because those packages require files that are not part of the projects that build the tools. That means that those packages don't know anything about the MSBuild project properties, so they didn't pick up the package license expression.

To fix that, we add a `<license type="expression">` tag to the package metadata in the .nuspec files. That leads to two more issues:

1. Version 4.3 of NuGet.exe, which we were using, doesn't recognize that tag. Therefore we upgrade to the latest NuGet.exe, Version 4.9.2.

2. We could hard-code `Apache-2.0` into the .nuspec files, but we would rather get it from the MSBuild properties, to ensure that it stays in sync with the packages that are created by `dotnet pack`. Therefore we add some code to BuildAndTest.ps1 to read the `PackageLicenseExpression` MSBuild property, and pass it on the NuGet.exe command line.

That takes care of #69.

While doing this, I noticed a couple of problems with the metadata of the other packages, the ones created by `dotnet pack`. This is #68.

1. They did not have a `Title` property. I fixed that by setting `<Title>` to `$(AssemblyTitle>)` in build.props.

2. They did not have the correct `Owners` property. There was in fact a bug in the setting of the `<Owners>` MSBuild property: the `Condition` was wrong. But fixing it does not fix the problem. After some research, it seems that `dotnet pack` does not respect `Owners` and always sets it to `Authors`, so there's nothing more I can do.

Finally, I fixed a couple of casing errors in the .nuspec files.