### PR TITLE
Set owners and authors strictly to Microsoft

### DIFF
--- a/src/build.props
+++ b/src/build.props
@@ -32,10 +32,9 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
-    <Title Condition=" '$(Title)' == '' ">$(AssemblyTitle)</Title>
-    <Authors Condition=" '$(Authors)' == '' ">$(Company),tse-securitytools</Authors>
-    <Owners Condition=" '$(Owners)' == '' ">$(Authors)</Owners>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Title>$(AssemblyTitle)</Title>
+    <Authors>$(Company)</Authors>
     <PackageRequireLicenseAcceptance Condition=" '$(PackageRequireLicenseAcceptance)' == '' ">false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Microsoft/jschema</PackageProjectUrl>


### PR DESCRIPTION
FYI, based on testing, the Authors element always flows to Owners. NuGet is rejecting authors that contains anything other than 'Microsoft'. We appear to need to strictly reference MS for both Authors and Owners. 

Presumably. I will try this and if it fails will consult with NuGet team later this week.

@lgolding 