### PR TITLE
Fix #108: Crash if property type is "array" and "items" is absent.

### DIFF
--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -406,8 +406,8 @@ namespace N
                 .WithMessage("*nonExistentDefinition*");
         }
 
-        [Fact(DisplayName = "DataModelGenerator generates array-valued property")]
-        public void GeneratesArrayValuedProperty()
+        [Fact(DisplayName = "DataModelGenerator generates array-valued properties")]
+        public void GeneratesArrayValuedProperties()
         {
             const string ExpectedClass =
 @"using System;
@@ -428,6 +428,10 @@ namespace N
 
         [DataMember(Name = ""arrayProp"", IsRequired = false, EmitDefaultValue = false)]
         public IList<object> ArrayProp { get; set; }
+        [DataMember(Name = ""arrayProp2"", IsRequired = false, EmitDefaultValue = false)]
+        public IList<int> ArrayProp2 { get; set; }
+        [DataMember(Name = ""arrayProp3"", IsRequired = false, EmitDefaultValue = false)]
+        public IList<object> ArrayProp3 { get; set; }
     }
 }";
 
@@ -479,6 +483,48 @@ namespace N
                 }
             }
 
+            if (!object.ReferenceEquals(left.ArrayProp2, right.ArrayProp2))
+            {
+                if (left.ArrayProp2 == null || right.ArrayProp2 == null)
+                {
+                    return false;
+                }
+
+                if (left.ArrayProp2.Count != right.ArrayProp2.Count)
+                {
+                    return false;
+                }
+
+                for (int index_1 = 0; index_1 < left.ArrayProp2.Count; ++index_1)
+                {
+                    if (left.ArrayProp2[index_1] != right.ArrayProp2[index_1])
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (!object.ReferenceEquals(left.ArrayProp3, right.ArrayProp3))
+            {
+                if (left.ArrayProp3 == null || right.ArrayProp3 == null)
+                {
+                    return false;
+                }
+
+                if (left.ArrayProp3.Count != right.ArrayProp3.Count)
+                {
+                    return false;
+                }
+
+                for (int index_2 = 0; index_2 < left.ArrayProp3.Count; ++index_2)
+                {
+                    if (!object.Equals(left.ArrayProp3[index_2], right.ArrayProp3[index_2]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
             return true;
         }
 
@@ -503,6 +549,27 @@ namespace N
                         }
                     }
                 }
+
+                if (obj.ArrayProp2 != null)
+                {
+                    foreach (var value_1 in obj.ArrayProp2)
+                    {
+                        result = result * 31;
+                        result = (result * 31) + value_1.GetHashCode();
+                    }
+                }
+
+                if (obj.ArrayProp3 != null)
+                {
+                    foreach (var value_2 in obj.ArrayProp3)
+                    {
+                        result = result * 31;
+                        if (value_2 != null)
+                        {
+                            result = (result * 31) + value_2.GetHashCode();
+                        }
+                    }
+                }
             }
 
             return result;
@@ -516,7 +583,7 @@ namespace N
 
             string actual = generator.Generate(schema);
 
-            TestUtil.WriteTestResultFiles(ExpectedClass, actual, nameof(GeneratesArrayValuedProperty));
+            TestUtil.WriteTestResultFiles(ExpectedClass, actual, nameof(GeneratesArrayValuedProperties));
 
             var expectedContentsDictionary = new Dictionary<string, ExpectedContents>
             {

--- a/src/Json.Schema.ToDotNet.UnitTests/TestData/Array.schema.json
+++ b/src/Json.Schema.ToDotNet.UnitTests/TestData/Array.schema.json
@@ -6,6 +6,15 @@
       "items": {
         "type": "object"
       }
+    },
+    "arrayProp2": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "arrayProp3": {
+      "type": "array"
     }
   },
   "minItems": 1

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -430,6 +430,21 @@ namespace Microsoft.Json.Schema.ToDotNet
             JsonSchema schema)
         {
             string key = MakeElementKeyName(propertyName);
+            if (schema.Items == null)
+            {
+                // If "items" is missing, it defaults to an empty schema, meaning the array
+                // element type can be anything. By treating it as if it were "items": "object",
+                // we will generate the same code, namely, a .NET array of System.Object.
+                schema.Items = new Items(
+                    new JsonSchema
+                    {
+                        Type = new List<SchemaType>
+                        {
+                            SchemaType.Object
+                        }
+                    });
+            }
+
             if (!schema.Items.SingleSchema)
             {
                 throw new ApplicationException($"Cannot generate code for the array property '{propertyName}' because the 'items' property of the schema contains different schemas for each array element.");

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -649,7 +649,11 @@ namespace Microsoft.Json.Schema.ToDotNet
         {
             TypeSyntax type = this[propertyName].Type;
 
-            string typeName = Regex.Replace(type.ToString(), "^IDictionary<", "Dictionary<");
+            string typeName = type.ToString();
+            if (typeName.StartsWith("IDictionary"))
+            {
+                typeName = typeName.Substring(1);
+            }
 
             return SyntaxFactory.ParseTypeName(typeName);
         }

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Json.Schema.ToDotNet.Hints;

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -641,12 +641,12 @@ namespace Microsoft.Json.Schema.ToDotNet
             return GetConcreteType(propertyName, "IDictionary");
         }
 
-        private TypeSyntax GetConcreteType(string propertyName, string abstractTypeName)
+        private TypeSyntax GetConcreteType(string propertyName, string interfaceName)
         {
             TypeSyntax type = this[propertyName].Type;
 
             string typeName = type.ToString();
-            if (typeName.StartsWith(abstractTypeName))
+            if (typeName.StartsWith(interfaceName))
             {
                 typeName = typeName.Substring(1);
                 type = SyntaxFactory.ParseTypeName(typeName);

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -629,9 +629,10 @@ namespace Microsoft.Json.Schema.ToDotNet
             if (typeName.StartsWith("IList"))
             {
                 typeName = typeName.Substring(1);
+                type = SyntaxFactory.ParseTypeName(typeName);
             }
 
-            return SyntaxFactory.ParseTypeName(typeName);
+            return type;
         }
 
         /// <summary>
@@ -652,9 +653,10 @@ namespace Microsoft.Json.Schema.ToDotNet
             if (typeName.StartsWith("IDictionary"))
             {
                 typeName = typeName.Substring(1);
+                type = SyntaxFactory.ParseTypeName(typeName);
             }
 
-            return SyntaxFactory.ParseTypeName(typeName);
+            return type;
         }
     }
 }

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -629,7 +629,7 @@ namespace Microsoft.Json.Schema.ToDotNet
             string typeName = type.ToString();
             if (typeName.StartsWith("IList"))
             {
-                typeName = Regex.Replace(type.ToString(), "^IList<", "List<");
+                typeName = typeName.Substring(1);
             }
 
             return SyntaxFactory.ParseTypeName(typeName);

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -623,16 +623,7 @@ namespace Microsoft.Json.Schema.ToDotNet
         /// </remarks>
         internal TypeSyntax GetConcreteListType(string propertyName)
         {
-            TypeSyntax type = this[propertyName].Type;
-
-            string typeName = type.ToString();
-            if (typeName.StartsWith("IList"))
-            {
-                typeName = typeName.Substring(1);
-                type = SyntaxFactory.ParseTypeName(typeName);
-            }
-
-            return type;
+            return GetConcreteType(propertyName, "IList");
         }
 
         /// <summary>
@@ -647,10 +638,15 @@ namespace Microsoft.Json.Schema.ToDotNet
         /// </remarks>
         internal TypeSyntax GetConcreteDictionaryType(string propertyName)
         {
+            return GetConcreteType(propertyName, "IDictionary");
+        }
+
+        private TypeSyntax GetConcreteType(string propertyName, string abstractTypeName)
+        {
             TypeSyntax type = this[propertyName].Type;
 
             string typeName = type.ToString();
-            if (typeName.StartsWith("IDictionary"))
+            if (typeName.StartsWith(abstractTypeName))
             {
                 typeName = typeName.Substring(1);
                 type = SyntaxFactory.ParseTypeName(typeName);

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -34,3 +34,8 @@
 ## **1.0.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.0.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.0.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.0.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.0.0)
 
 * Update SARIF dependency to v2.1.0.
+
+## **1.0.1** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.0.1) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.0.1)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.0.1)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.0.1)
+
+* #108: Bug fix: The code generator crashed on a schema with `"type": "array"` but no `"items"` property.
+According to JSON Schema, that is equivalent to `"items": { }`, meaning anything is allowed, meaning this construct should generate an array whose elements are `System.Object`.

--- a/src/build.props
+++ b/src/build.props
@@ -13,7 +13,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
If a property has `"type": "array"` and `"items"` is missing, then `"items`" is equivalent to an empty schema, meaning it can hold anything. In this case, produce a .NET array element type of `object`.