### PR TITLE
Fixed the copy constructor to allow for relative refs

### DIFF
--- a/src/Json.Schema/UriOrFragment.cs
+++ b/src/Json.Schema/UriOrFragment.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Json.Schema
 
             if (other.Uri != null)
             {
-                Uri = new Uri(other.Uri.OriginalString);
+                Uri = new Uri(other.Uri.OriginalString, UriKind.RelativeOrAbsolute);
             }
         }
 


### PR DESCRIPTION
Found a bug while trying to load some schemas with relative refs in a union. Fails with a UriFormatException. 