### PR TITLE
Update validator to use latest SARIF SDK (2.4.14)

### DIFF
--- a/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.csproj
+++ b/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.csproj
+++ b/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="Sarif.Sdk" Version="2.3.3" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Json.Schema.Validation.Cli/Program.cs
+++ b/src/Json.Schema.Validation.Cli/Program.cs
@@ -43,7 +43,23 @@ namespace Microsoft.Json.Schema.Validation.CommandLine
                                             options.InstanceFilePath,
                                             options.SchemaFilePath
                                         },
-                                        loggingOptions: LoggingOptions.Verbose,
+                                        kinds: new[]
+                                        {
+                                            ResultKind.Fail,
+                                            ResultKind.Informational,
+                                            ResultKind.None,
+                                            ResultKind.NotApplicable,
+                                            ResultKind.Open,
+                                            ResultKind.Pass,
+                                            ResultKind.Review
+                                        },
+                                        levels: new[]
+                                        {
+                                            FailureLevel.Error,
+                                            FailureLevel.None,
+                                            FailureLevel.Note,
+                                            FailureLevel.Warning,
+                                        },
                                         invocationTokensToRedact: null))
             {
                 DateTime start = DateTime.Now;

--- a/src/Json.Schema.Validation.UnitTests/Json.Schema.Validation.UnitTests.csproj
+++ b/src/Json.Schema.Validation.UnitTests/Json.Schema.Validation.UnitTests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Sarif.Sdk" Version="2.3.3" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/Json.Schema.Validation.UnitTests/Json.Schema.Validation.UnitTests.csproj
+++ b/src/Json.Schema.Validation.UnitTests/Json.Schema.Validation.UnitTests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.14" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile-validation-expected.sarif
+++ b/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile-validation-expected.sarif
@@ -20,8 +20,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 82,
@@ -49,8 +48,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 84,
@@ -79,8 +77,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 87,
@@ -109,8 +106,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 90,
@@ -138,8 +134,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 94,
@@ -168,8 +163,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 97,
@@ -198,8 +192,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 100,
@@ -228,8 +221,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 103,
@@ -258,8 +250,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 106,
@@ -288,8 +279,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 108,
@@ -318,8 +308,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 113,
@@ -348,8 +337,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 117,
@@ -379,8 +367,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 120,
@@ -410,8 +397,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 123,
@@ -440,8 +426,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 126,
@@ -469,8 +454,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 129,
@@ -498,8 +482,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 132,
@@ -528,8 +511,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 135,
@@ -558,8 +540,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 138,
@@ -588,8 +569,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 141,
@@ -616,8 +596,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 144,
@@ -646,8 +625,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 147,
@@ -674,8 +652,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 150,
@@ -705,8 +682,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
-                  "index": 2
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
                 },
                 "region": {
                   "startLine": 152,
@@ -1098,17 +1074,12 @@
       "artifacts": [
         {
           "location": {
-            "uri": "ComprehensiveInstanceFile.json"
+            "uri": "TestData/ComprehensiveInstanceFile.json"
           }
         },
         {
           "location": {
-            "uri": "ComprehensiveSchema.json"
-          }
-        },
-        {
-          "location": {
-            "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+            "uri": "TestData/ComprehensiveSchema.json"
           }
         }
       ],

--- a/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile-validation-expected.sarif
+++ b/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile-validation-expected.sarif
@@ -20,7 +20,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 82,
@@ -48,7 +49,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 84,
@@ -77,7 +79,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 87,
@@ -106,7 +109,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 90,
@@ -134,7 +138,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 94,
@@ -163,7 +168,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 97,
@@ -192,7 +198,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 100,
@@ -221,7 +228,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 103,
@@ -250,7 +258,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 106,
@@ -279,7 +288,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 108,
@@ -308,7 +318,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 113,
@@ -337,7 +348,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 117,
@@ -367,7 +379,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 120,
@@ -397,7 +410,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 123,
@@ -426,7 +440,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 126,
@@ -454,7 +469,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 129,
@@ -482,7 +498,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 132,
@@ -511,7 +528,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 135,
@@ -540,7 +558,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 138,
@@ -569,7 +588,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 141,
@@ -596,7 +616,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 144,
@@ -625,7 +646,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 147,
@@ -652,7 +674,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 150,
@@ -682,7 +705,8 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
+                  "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json",
+                  "index": 2
                 },
                 "region": {
                   "startLine": 152,
@@ -698,12 +722,11 @@
       ],
       "tool": {
         "driver": {
-          "name": "Microsoft.Json.Schema.Validation.Cli",
-          "organization": "Microsoft",
-          "product": "JSON Schema",
-          "fullName": "Microsoft.Json.Schema.Validation.Cli 1.1.3.0",
-          "version": "1.1.3.0",
-          "semanticVersion": "1.1.3",
+          "name": "testhost",
+          "product": "Microsoft.TestHost",
+          "fullName": "testhost 15.0.0.0",
+          "version": "15.0.0.0",
+          "semanticVersion": "15.0.0",
           "rules": [
             {
               "id": "JSON1001",
@@ -1050,20 +1073,17 @@
                 "level": "error"
               }
             }
-          ],
-          "properties": {
-            "Comments": "Command line tool to validate a JSON instance against a JSON Schema"
-          }
+          ]
         }
       },
       "invocations": [
         {
-          "startTimeUtc": "2020-07-28T15:22:49.841Z",
-          "endTimeUtc": "2020-07-28T15:22:50.230Z",
+          "startTimeUtc": "2022-04-22T20:26:56.699Z",
+          "endTimeUtc": "2022-04-22T20:26:56.802Z",
           "toolExecutionNotifications": [
             {
               "message": {
-                "text": "Validation time: 00:00:00.3672531"
+                "text": "Validation time: 00:00:00.0954495"
               },
               "level": "note"
             }
@@ -1080,6 +1100,11 @@
         {
           "location": {
             "uri": "TestData/ComprehensiveSchema.json"
+          }
+        },
+        {
+          "location": {
+            "uri": "file:///c:/dev/jschema/src/Json.Schema.Validation.UnitTests/TestData/ComprehensiveInstanceFile.json"
           }
         }
       ],

--- a/src/Json.Schema.Validation/Json.Schema.Validation.csproj
+++ b/src/Json.Schema.Validation/Json.Schema.Validation.csproj
@@ -12,7 +12,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Json.Schema.Validation/Json.Schema.Validation.csproj
+++ b/src/Json.Schema.Validation/Json.Schema.Validation.csproj
@@ -12,7 +12,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Sarif.Sdk" Version="2.3.3" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,12 @@
 # Microsoft Json Schema Packages
 
+## **1.1.4** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.4) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.4)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.4)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.4)
+
+* Update validator to use latest SARIF SDK (2.4.12).
+* Fixing wrong array logic.
+* Enable symbols.
+* Set up CI with Azure Pipelines.
+
 ## **1.1.3** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.3) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.3)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.3)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.3)
 
 * Improve error messages: Remove unnecessary words; fix some typos; unify on single quotes.

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,8 +1,8 @@
 # Microsoft Json Schema Packages
 
-## **1.1.4** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.4) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.4)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.4)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.4)
+## **Unreleased**
 
-* Update validator to use latest SARIF SDK (2.4.12).
+* Update validator to use latest SARIF SDK (2.4.14).
 * Fixing wrong array logic.
 * Enable symbols.
 * Set up CI with Azure Pipelines.

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.4</VersionPrefix>
+    <VersionPrefix>1.1.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
1. Update validator to use latest SARIF SDK (2.4.14)
2. I see SDK 2.3.3->2.4.14 have minor difference on the generated sarif for test input, fix the test with current output.