### PR TITLE
Migrating to netcoreapp3.1

### DIFF
--- a/BuildAndTest.ps1
+++ b/BuildAndTest.ps1
@@ -172,7 +172,7 @@ if (-not $NoPackage) {
 
     $nuspecProjects = "Json.Schema.ToDotNet.Cli", "Json.Schema.Validation.Cli"
     foreach ($project in $nuspecProjects) {
-        Publish-Application $project netcoreapp2.1
+        Publish-Application $project netcoreapp3.1
         New-NuGetPackageFromNuSpecFile $project $version $(Get-PackageLicenseExpression)
     }
 }

--- a/CreateSigningDirectory.cmd
+++ b/CreateSigningDirectory.cmd
@@ -23,7 +23,7 @@ set SigningDirectory=%BinaryOutputDirectory%\..\Signing
 
 call :CreateDirIfNotExist %SigningDirectory%
 call :CreateDirIfNotExist %SigningDirectory%\net461\
-call :CreateDirIfNotExist %SigningDirectory%\netcoreapp2.1
+call :CreateDirIfNotExist %SigningDirectory%\netcoreapp3.1
 
 call :CopyUnsignedLibraryToSigningDirectory Json.Schema.dll            || goto :ExitFailed
 call :CopyUnsignedLibraryToSigningDirectory Json.Pointer.dll           || goto :ExitFailed
@@ -36,7 +36,7 @@ call :CopyUnsignedExecutableToSigningDirectory Json.Schema.Validation.Cli || got
 goto :Exit
 
 :CopyUnsignedLibraryToSigningDirectory
-xcopy /Y %BinaryOutputDirectory%\%~n1\netstandard2.0\Microsoft.%1  %SigningDirectory%\netcoreapp2.1\
+xcopy /Y %BinaryOutputDirectory%\%~n1\netstandard2.0\Microsoft.%1  %SigningDirectory%\netcoreapp3.1\
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 
 xcopy /Y %BinaryOutputDirectory%\%~n1\net461\Microsoft.%1  %SigningDirectory%\net461\
@@ -44,7 +44,7 @@ if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed.)
 goto :CopyFilesExit
 
 :CopyUnsignedExecutableToSigningDirectory
-xcopy /Y %BinaryOutputDirectory%\%1\netcoreapp2.1\Microsoft.%1.dll  %SigningDirectory%\netcoreapp2.1\
+xcopy /Y %BinaryOutputDirectory%\%1\netcoreapp3.1\Microsoft.%1.dll  %SigningDirectory%\netcoreapp3.1\
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 
 xcopy /Y %BinaryOutputDirectory%\%1\net461\Microsoft.%1.exe  %SigningDirectory%\net461\

--- a/PushSignedBinariesIntoBuild.cmd
+++ b/PushSignedBinariesIntoBuild.cmd
@@ -34,7 +34,7 @@ goto :Exit
 
 :CopySignedLibraryToBuildOutputDirectory
 
-xcopy /Y %SigningDirectory%\netcoreapp2.1\Microsoft.%1 %BinaryOutputDirectory%\%~n1\netstandard2.0\
+xcopy /Y %SigningDirectory%\netcoreapp3.1\Microsoft.%1 %BinaryOutputDirectory%\%~n1\netstandard2.0\
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 
 xcopy /Y %SigningDirectory%\net461\Microsoft.%1 %BinaryOutputDirectory%\%~n1\net461\
@@ -43,7 +43,7 @@ goto :CopyFilesExit
 
 :CopySignedExecutableToBuildOutputDirectory
 
-xcopy /Y %SigningDirectory%\netcoreapp2.1\Microsoft.%1.dll %BinaryOutputDirectory%\%1\netstandard2.0\
+xcopy /Y %SigningDirectory%\netcoreapp3.1\Microsoft.%1.dll %BinaryOutputDirectory%\%1\netstandard2.0\
 if "%ERRORLEVEL%" NEQ "0" (echo %1 assembly copy failed. && goto :CopyFilesExit)
 
 xcopy /Y %SigningDirectory%\net461\Microsoft.%1.exe %BinaryOutputDirectory%\%1\net461\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ steps:
 - task: BatchScript@1
   displayName: 'Run VsDevCmd.bat'
   inputs:
-    filename: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat'
+    filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat'
     modifyEnvironment: true
 
 - task: PowerShell@2

--- a/src/Everything.sln
+++ b/src/Everything.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32210.308
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Json.Pointer", "Json.Pointer\Json.Pointer.csproj", "{370BB86D-4EC4-4BA9-BED3-3922B078C692}"
 EndProject
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{14BA185B-9
 	ProjectSection(SolutionItems) = preProject
 		..\.gitattributes = ..\.gitattributes
 		..\.gitignore = ..\.gitignore
+		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		build.props = build.props
 		..\BuildAndTest.cmd = ..\BuildAndTest.cmd
 		..\License.txt = ..\License.txt

--- a/src/Json.Pointer.UnitTests/Json.Pointer.UnitTests.csproj
+++ b/src/Json.Pointer.UnitTests/Json.Pointer.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Json.Schema.PerformanceTests/Json.Schema.PerformanceTests.csproj
+++ b/src/Json.Schema.PerformanceTests/Json.Schema.PerformanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
+++ b/src/Json.Schema.ToDotNet.Cli/Json.Schema.ToDotNet.Cli.nuspec
@@ -28,8 +28,8 @@
           target="tools\net461"
           />
     
-    <file src="bld\bin\$platform$_$configuration$\Json.Schema.ToDotNet.Cli\netcoreapp2.1\publish\**"
-          target="tools\netcoreapp2.1"
+    <file src="bld\bin\$platform$_$configuration$\Json.Schema.ToDotNet.Cli\netcoreapp3.1\publish\**"
+          target="tools\netcoreapp3.1"
           />
 
     <file src="src\ReleaseHistory.md" />

--- a/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
+++ b/src/Json.Schema.Validation.Cli/Json.Schema.Validation.Cli.nuspec
@@ -28,8 +28,8 @@
           target="tools\net461"
           />
 
-    <file src="bld\bin\$platform$_$configuration$\Json.Schema.Validation.Cli\netcoreapp2.1\publish\**"
-          target="tools\netcoreapp2.1"
+    <file src="bld\bin\$platform$_$configuration$\Json.Schema.Validation.Cli\netcoreapp3.1\publish\**"
+          target="tools\netcoreapp3.1"
           />
 
     <file src="src\ReleaseHistory.md" />

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -6,6 +6,7 @@
 * Update validator to use latest SARIF SDK (2.3.3).
 * Add end-to-end test of validation.
 * Fix bug in validation of arrays with item schemas.
+* Updating client tool to support netcoreapp3.1.
 
 ## **1.1.2** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.2) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.2)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.2)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.2)
 


### PR DESCRIPTION
# Description

This change is updating the following:
- azure pipelines to point to vs2022 folder
- scripts to use `netcoreapp3.1` folders instead of `netcoreapp2.x`

Once this gets merged, we should publish a new version (1.1.3), which will release a new version with supported client tools.