### PR TITLE
Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1

### DIFF
--- a/src/Json.Pointer/Json.Pointer.csproj
+++ b/src/Json.Pointer/Json.Pointer.csproj
@@ -16,7 +16,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/Json.Schema.ToDotNet.Cli/Program.cs
+++ b/src/Json.Schema.ToDotNet.Cli/Program.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using CommandLine;
 using Microsoft.Json.Schema.ToDotNet.Hints;
+using Newtonsoft.Json;
 
 namespace Microsoft.Json.Schema.ToDotNet.CommandLine
 {
@@ -16,6 +17,9 @@ namespace Microsoft.Json.Schema.ToDotNet.CommandLine
     {
         private static int Main(string[] args)
         {
+            // Mitigation for Newtonsoft.Json < v13 vulnerability GHSA-5crp-9r3c-p9vr
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings { MaxDepth = 64 };
+
             Banner();
 
             return Parser.Default.ParseArguments<Options>(args)

--- a/src/Json.Schema.ToDotNet.UnitTests/Json.Schema.ToDotNet.UnitTests.csproj
+++ b/src/Json.Schema.ToDotNet.UnitTests/Json.Schema.ToDotNet.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="FluentAssertions" Version="5.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/Json.Schema.ToDotNet.UnitTests/Json.Schema.ToDotNet.UnitTests.csproj
+++ b/src/Json.Schema.ToDotNet.UnitTests/Json.Schema.ToDotNet.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="FluentAssertions" Version="5.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/src/Json.Schema.ToDotNet/Json.Schema.ToDotNet.csproj
+++ b/src/Json.Schema.ToDotNet/Json.Schema.ToDotNet.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Json.Schema/Json.Schema.csproj
+++ b/src/Json.Schema/Json.Schema.csproj
@@ -16,7 +16,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.props))\build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # Microsoft Json Schema Packages
 
 ## **Unreleased**
-* Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1 [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1).
+* Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1 [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1). [#157](https://github.com/microsoft/jschema/pull/157)
 
 ## **1.1.5** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.5) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.4)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.4)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.5)
 * Updating [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/13.0.1) from v9.0.1 to v13.0.1 in response to [Advisory: Improper Handling of Exceptional Conditions in Newtonsoft.Json](https://github.com/advisories/GHSA-5crp-9r3c-p9vr). [#155](https://github.com/microsoft/jschema/pull/155)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # Microsoft Json Schema Packages
 
+## **Unreleased**
+* Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1 [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1).
+
 ## **1.1.5** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.5) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.4)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.4)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.5)
 * Updating [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/13.0.1) from v9.0.1 to v13.0.1 in response to [Advisory: Improper Handling of Exceptional Conditions in Newtonsoft.Json](https://github.com/advisories/GHSA-5crp-9r3c-p9vr). [#155](https://github.com/microsoft/jschema/pull/155)
 


### PR DESCRIPTION
The is the same action as the SARIF SDK to "loosen min version requirement to 6.0.8 for .NET FX, 9.0.1 otherwise".
The jschema project is not on .NET FX, so we are using v9.0.1
Before it was upgraded to v13.0.1, it was on v9.0.1
so the change should be minimum impact, which is a basically a revert.