### PR TITLE
Releasing 2.0.0

### DIFF
--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # Microsoft Json Schema Packages
 
-## **Unreleased**
+## **1.1.6** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.6) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.6)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.6)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.6)
 * Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1 [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1). [#157](https://github.com/microsoft/jschema/pull/157)
 * FEATURE: Add support for JSON Schema type `uuid`. [#132](https://github.com/microsoft/jschema/pull/132)
 * FEATURE: Add new option for specifying .NET type to express Json integers: `--generate-json-integer-as = int | long | biginteger | auto` with a default of `int`. [#158](https://github.com/microsoft/jschema/pull/158)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # Microsoft Json Schema Packages
 
-## **1.1.6** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/1.1.6) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/1.1.6)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/1.1.6)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/1.1.6)
+## **2.0.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.0.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.0.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.0.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.0.0)
 * Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1 [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1). [#157](https://github.com/microsoft/jschema/pull/157)
 * FEATURE: Add support for JSON Schema type `uuid`. [#132](https://github.com/microsoft/jschema/pull/132)
 * FEATURE: Add new option for specifying .NET type to express Json integers: `--generate-json-integer-as = int | long | biginteger | auto` with a default of `int`. [#158](https://github.com/microsoft/jschema/pull/158)

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.6</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>1.1.5</VersionPrefix>
+    <VersionPrefix>1.1.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
# Microsoft Json Schema Packages

## **2.0.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.0.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.0.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.0.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.0.0)
* Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1 [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1). [#157](https://github.com/microsoft/jschema/pull/157)
* FEATURE: Add support for JSON Schema type `uuid`. [#132](https://github.com/microsoft/jschema/pull/132)
* FEATURE: Add new option for specifying .NET type to express Json integers: `--generate-json-integer-as = int | long | biginteger | auto` with a default of `int`. [#158](https://github.com/microsoft/jschema/pull/158)
