### PR TITLE
Support Nullable Guid

### DIFF
--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -477,6 +477,44 @@ namespace N
             GeneratesPropertiesWithIntegerTypes_Helper(GenerateJsonIntegerOption.Int, ExpectedClass_Int);
         }
 
+        [Fact(DisplayName = "DataModelGenerator generates properties with Uuid types")]
+        public void GeneratesPropertiesWithUuidTypes()
+        {
+            const string ExpectedClass =
+@"using System;
+using System.CodeDom.Compiler;
+using System.Runtime.Serialization;
+
+namespace N
+{
+    [DataContract]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.0.0.0"")]
+    public partial class C
+    {
+        [DataMember(Name = ""uuid_not_required"", IsRequired = false, EmitDefaultValue = false)]
+        public Guid? Uuid_not_required { get; set; }
+        [DataMember(Name = ""uuid_required"", IsRequired = true)]
+        public Guid Uuid_required { get; set; }
+    }
+}";
+            _settings.GenerateEqualityComparers = false;
+            _settings.GenerateComparers = false;
+            var generator = new DataModelGenerator(_settings, _testFileSystem.FileSystem);
+            JsonSchema schema = TestUtil.CreateSchemaFromTestDataFile("Uuid");
+            var expectedContentsDictionary = new Dictionary<string, ExpectedContents>
+            {
+                [_settings.RootClassName] = new ExpectedContents
+                {
+                    ClassContents = ExpectedClass
+                }
+            };
+
+            generator.Generate(schema);
+
+            VerifyGeneratedFileContents(expectedContentsDictionary);
+            _testFileSystem = new TestFileSystem();
+        }
+
         [Fact(DisplayName = "DataModelGenerator generates object-valued property with correct type")]
         public void GeneratesObjectValuedPropertyWithCorrectType()
         {

--- a/src/Json.Schema.ToDotNet.UnitTests/TestData/Uuid.schema.json
+++ b/src/Json.Schema.ToDotNet.UnitTests/TestData/Uuid.schema.json
@@ -1,0 +1,14 @@
+﻿{
+  "type": "object",
+  "properties": {
+    "uuid_not_required": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "uuid_required": {
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [ "uuid_required" ]
+}

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -248,9 +248,9 @@ namespace Microsoft.Json.Schema.ToDotNet
             else if (propertySchema.IsUuid())
             {
                 comparisonKind = ComparisonKind.OperatorEquals;
-                hashKind = HashKind.ScalarValueType;
+                hashKind = isRequired ? HashKind.ScalarValueType : HashKind.ScalarReferenceType;
                 initializationKind = InitializationKind.SimpleAssign;
-                type = MakeNamedType("System.Guid", out namespaceName);
+                type = MakeNamedType(isRequired ? "System.Guid" : "System.Guid?", out namespaceName);
             }
             else if (propertySchema.ShouldBeDictionary(_typeName, schemaPropertyName, _hintDictionary, out DictionaryHint dictionaryHint))
             {

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # Microsoft Json Schema Packages
 
+## **Unreleased**
+* FEATURE: Add support for JSON Schema type `uuid` generate as C# nullable `Guid?`. [#164](https://github.com/microsoft/jschema/pull/164)
+
 ## **2.0.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.0.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.0.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.0.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.0.0)
 * Loosen Newtonsoft.JSON minimum version requirement from v13.0.1 to v9.0.1 [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/9.0.1). [#157](https://github.com/microsoft/jschema/pull/157)
 * FEATURE: Add support for JSON Schema type `uuid`. [#132](https://github.com/microsoft/jschema/pull/132)


### PR DESCRIPTION
This add feature to generate  `Guid?` when the `uuid` property is not required , and  `Guid` when it is.
Without this, for those using C# `string` was able to use C# `null`; but not now with the newly added C# `Guid` type.
