### PR TITLE
Releasing 2.1.0

### DIFF
--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -488,7 +488,7 @@ using System.Runtime.Serialization;
 namespace N
 {
     [DataContract]
-    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.0.0.0"")]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", """ + VersionConstants.FileVersion + @""")]
     public partial class C
     {
         [DataMember(Name = ""uuid_not_required"", IsRequired = false, EmitDefaultValue = false)]

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # Microsoft Json Schema Packages
 
-## **Unreleased**
+## **2.1.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.1.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.1.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.1.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.1.0)
 * FEATURE: Add support for JSON Schema type `uuid` generate as C# nullable `Guid?`. [#164](https://github.com/microsoft/jschema/pull/164)
 
 ## **2.0.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.0.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.0.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.0.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.0.0)

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
# Microsoft Json Schema Packages

## **2.1.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.1.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.1.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.1.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.1.0)
* FEATURE: Add support for JSON Schema type `uuid` generate as C# nullable `Guid?`. [#164](https://github.com/microsoft/jschema/pull/164)
