### PR TITLE
FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`.

### DIFF
--- a/src/Json.Schema.ToDotNet.Cli/Options.cs
+++ b/src/Json.Schema.ToDotNet.Cli/Options.cs
@@ -100,6 +100,13 @@ namespace Microsoft.Json.Schema.ToDotNet.CommandLine
         public GenerateJsonIntegerOption GenerateJsonIntegerAs { get; set; }
 
         [Option(
+            "generate-json-number-as",
+            HelpText = "Generate Json number as C# type: double|float|decimal.",
+            Default = GenerateJsonNumberOption.Double,
+            Required = false)]
+        public GenerateJsonNumberOption GenerateJsonNumberAs { get; set; }
+
+        [Option(
             "seal-classes",
             HelpText = "Seal generated classes.",
             Default = false,

--- a/src/Json.Schema.ToDotNet.Cli/Program.cs
+++ b/src/Json.Schema.ToDotNet.Cli/Program.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Json.Schema.ToDotNet.CommandLine
                     GenerateComparers = options.GenerateComparers,
                     GenerateCloningCode = options.GenerateCloningCode,
                     GenerateJsonIntegerAs = options.GenerateJsonIntegerAs,
+                    GenerateJsonNumberAs = options.GenerateJsonNumberAs,
                     SealClasses = options.SealClasses,
                     VirtualMembers = options.VirtualMembers,
                     ProtectedInitMethods = options.ProtectedInitMethods

--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -477,6 +477,143 @@ namespace N
             GeneratesPropertiesWithIntegerTypes_Helper(GenerateJsonIntegerOption.Int, ExpectedClass_Int);
         }
 
+        [Fact(DisplayName = "DataModelGenerator generates properties with number types")]
+        public void GeneratesPropertiesWithNumberTypes()
+        {
+            const string ExpectedClass_Double =
+@"using System;
+using System.CodeDom.Compiler;
+using System.Runtime.Serialization;
+
+namespace N
+{
+    [DataContract]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.1.0.0"")]
+    public partial class C
+    {
+        [DataMember(Name = ""numberProperty_default"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_default { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_0_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_minus1_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_minus1_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_1_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_1_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_na_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_na_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_floattimes10"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_0_max_floattimes10 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_float"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_0_max_float { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_decimaladd1"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_0_max_decimaladd1 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_decimal"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_0_max_decimal { get; set; }
+        [DataMember(Name = ""numberProperty_min_decimal_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_decimal_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_decimalminus1_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_decimalminus1_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_float_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_float_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_floattimes10_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_floattimes10_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_double_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_double_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_double"", IsRequired = false, EmitDefaultValue = false)]
+        public double NumberProperty_min_0_max_double { get; set; }
+    }
+}";
+            const string ExpectedClass_Float =
+@"using System;
+using System.CodeDom.Compiler;
+using System.Runtime.Serialization;
+
+namespace N
+{
+    [DataContract]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.1.0.0"")]
+    public partial class C
+    {
+        [DataMember(Name = ""numberProperty_default"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_default { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_0_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_minus1_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_minus1_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_1_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_1_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_na_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_na_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_floattimes10"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_0_max_floattimes10 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_float"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_0_max_float { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_decimaladd1"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_0_max_decimaladd1 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_decimal"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_0_max_decimal { get; set; }
+        [DataMember(Name = ""numberProperty_min_decimal_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_decimal_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_decimalminus1_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_decimalminus1_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_float_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_float_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_floattimes10_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_floattimes10_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_double_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_double_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_double"", IsRequired = false, EmitDefaultValue = false)]
+        public float NumberProperty_min_0_max_double { get; set; }
+    }
+}";
+            const string ExpectedClass_Decimal =
+@"using System;
+using System.CodeDom.Compiler;
+using System.Runtime.Serialization;
+
+namespace N
+{
+    [DataContract]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.1.0.0"")]
+    public partial class C
+    {
+        [DataMember(Name = ""numberProperty_default"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_default { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_0_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_minus1_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_minus1_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_1_max_na"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_1_max_na { get; set; }
+        [DataMember(Name = ""numberProperty_min_na_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_na_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_floattimes10"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_0_max_floattimes10 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_float"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_0_max_float { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_decimaladd1"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_0_max_decimaladd1 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_decimal"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_0_max_decimal { get; set; }
+        [DataMember(Name = ""numberProperty_min_decimal_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_decimal_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_decimalminus1_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_decimalminus1_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_float_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_float_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_floattimes10_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_floattimes10_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_double_max_0"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_double_max_0 { get; set; }
+        [DataMember(Name = ""numberProperty_min_0_max_double"", IsRequired = false, EmitDefaultValue = false)]
+        public decimal NumberProperty_min_0_max_double { get; set; }
+    }
+}";
+            GeneratesPropertiesWithNumberTypes_Helper(GenerateJsonNumberOption.Double, ExpectedClass_Double);
+            GeneratesPropertiesWithNumberTypes_Helper(GenerateJsonNumberOption.Float, ExpectedClass_Float);
+            GeneratesPropertiesWithNumberTypes_Helper(GenerateJsonNumberOption.Decimal, ExpectedClass_Decimal);
+        }
+
         [Fact(DisplayName = "DataModelGenerator generates properties with Uuid types")]
         public void GeneratesPropertiesWithUuidTypes()
         {
@@ -5246,6 +5383,27 @@ namespace N
             _settings.GenerateJsonIntegerAs = generateJsonIntegerAs;
             var generator = new DataModelGenerator(_settings, _testFileSystem.FileSystem);
             JsonSchema schema = TestUtil.CreateSchemaFromTestDataFile("Integer");
+            var expectedContentsDictionary = new Dictionary<string, ExpectedContents>
+            {
+                [_settings.RootClassName] = new ExpectedContents
+                {
+                    ClassContents = expectedClass
+                }
+            };
+
+            generator.Generate(schema);
+
+            VerifyGeneratedFileContents(expectedContentsDictionary);
+            _testFileSystem = new TestFileSystem();
+        }
+
+        private void GeneratesPropertiesWithNumberTypes_Helper(GenerateJsonNumberOption generateJsonNumberAs, string expectedClass)
+        {
+            _settings.GenerateEqualityComparers = false;
+            _settings.GenerateComparers = false;
+            _settings.GenerateJsonNumberAs = generateJsonNumberAs;
+            var generator = new DataModelGenerator(_settings, _testFileSystem.FileSystem);
+            JsonSchema schema = TestUtil.CreateSchemaFromTestDataFile("Number");
             var expectedContentsDictionary = new Dictionary<string, ExpectedContents>
             {
                 [_settings.RootClassName] = new ExpectedContents

--- a/src/Json.Schema.ToDotNet.UnitTests/TestData/Number.schema.json
+++ b/src/Json.Schema.ToDotNet.UnitTests/TestData/Number.schema.json
@@ -1,0 +1,74 @@
+﻿{
+  "type": "object",
+  "properties": {
+    "numberProperty_default": {
+      "type": "number"
+    },
+    "numberProperty_min_0_max_na": {
+      "type": "number",
+      "minimum": 0
+    },
+    "numberProperty_min_minus1_max_na": {
+      "type": "number",
+      "minimum": -1
+    },
+    "numberProperty_min_1_max_na": {
+      "type": "number",
+      "minimum": 1
+    },
+    "numberProperty_min_na_max_0": {
+      "type": "number",
+      "maximum": 0
+    },
+    "numberProperty_min_0_max_floattimes10": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 3.40282347E+39
+    },
+    "numberProperty_min_0_max_float": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 3.40282347E+38
+    },
+    "numberProperty_min_0_max_decimaladd1": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 79228162514264337593543950336
+    },
+    "numberProperty_min_0_max_decimal": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 79228162514264337593543950335
+    },
+    "numberProperty_min_decimal_max_0": {
+      "type": "number",
+      "minimum": -79228162514264337593543950335,
+      "maximum": 0
+    },
+    "numberProperty_min_decimalminus1_max_0": {
+      "type": "number",
+      "minimum": -79228162514264337593543950336,
+      "maximum": 0
+    },
+    "numberProperty_min_float_max_0": {
+      "type": "number",
+      "minimum": -3.40282347E+38,
+      "maximum": 0
+    },
+    "numberProperty_min_floattimes10_max_0": {
+      "type": "number",
+      "minimum": -3.40282347E+39,
+      "maximum": 0
+    },
+    "numberProperty_min_double_max_0": {
+      "type": "number",
+      "minimum": -1.7976931348623157E+308,
+      "maximum": 0
+    },
+    "numberProperty_min_0_max_double": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1.7976931348623157E+308
+    }
+  }
+}

--- a/src/Json.Schema.ToDotNet/DataModelGenerator.cs
+++ b/src/Json.Schema.ToDotNet/DataModelGenerator.cs
@@ -309,7 +309,8 @@ namespace Microsoft.Json.Schema.ToDotNet
                 schema,
                 _settings.HintDictionary,
                 OnAdditionalTypeRequired,
-                _settings.GenerateJsonIntegerAs);
+                _settings.GenerateJsonIntegerAs,
+                _settings.GenerateJsonNumberAs);
 
             _classInfoDictionary.Add(suffixedClassName, propertyInfoDictionary);
 

--- a/src/Json.Schema.ToDotNet/DataModelGeneratorSettings.cs
+++ b/src/Json.Schema.ToDotNet/DataModelGeneratorSettings.cs
@@ -88,6 +88,11 @@ namespace Microsoft.Json.Schema.ToDotNet
         public GenerateJsonIntegerOption GenerateJsonIntegerAs { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating what C# type to emit for Json numbers.
+        /// </summary>
+        public GenerateJsonNumberOption GenerateJsonNumberAs { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the generated classes should
         /// be declared <code>sealed</code>. If <code>false</code>, the generated
         /// classes are declared <code>partial</code>.

--- a/src/Json.Schema.ToDotNet/GenerateNumberOption.cs
+++ b/src/Json.Schema.ToDotNet/GenerateNumberOption.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.Json.Schema.ToDotNet
+{
+    /// <summary>
+    /// Values that specify the C# type to be generated
+    /// for each Json Number property.
+    /// </summary>
+    public enum GenerateJsonNumberOption
+    {
+        /// <summary>
+        /// C# double type
+        /// </summary>
+        Double,
+
+        /// <summary>
+        /// C# float type
+        /// </summary>
+        Float,
+
+        /// <summary>
+        /// C# decimal type
+        /// </summary>
+        Decimal,
+    }
+}

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Json.Schema.ToDotNet
 
         private readonly AdditionalTypeRequiredDelegate _additionalTypeRequiredDelegate;
         private readonly GenerateJsonIntegerOption _generateJsonIntegerAs;
+        private readonly GenerateJsonNumberOption _generateJsonNumberAs;
         private readonly string _typeNameSuffix;
 
         /// <summary>
@@ -79,7 +80,8 @@ namespace Microsoft.Json.Schema.ToDotNet
             JsonSchema schema,
             HintDictionary hintDictionary,
             AdditionalTypeRequiredDelegate additionalTypeRequiredDelegate,
-            GenerateJsonIntegerOption generateJsonIntegerAs)
+            GenerateJsonIntegerOption generateJsonIntegerAs,
+            GenerateJsonNumberOption generateJsonNumberAs)
         {
             _typeName = typeName;
             _typeNameSuffix = typeNameSuffix;
@@ -87,6 +89,7 @@ namespace Microsoft.Json.Schema.ToDotNet
             _hintDictionary = hintDictionary;
             _additionalTypeRequiredDelegate = additionalTypeRequiredDelegate;
             _generateJsonIntegerAs = generateJsonIntegerAs;
+            _generateJsonNumberAs = generateJsonNumberAs;
 
             _dictionary = PropertyInfoDictionaryFromSchema();
         }
@@ -296,11 +299,16 @@ namespace Microsoft.Json.Schema.ToDotNet
                 switch (propertyType)
                 {
                     case SchemaType.Boolean:
-                    case SchemaType.Number:
                         comparisonKind = ComparisonKind.OperatorEquals;
                         hashKind = HashKind.ScalarValueType;
                         initializationKind = InitializationKind.SimpleAssign;
                         type = MakePrimitiveType(propertyType);
+                        break;
+                    case SchemaType.Number:
+                        comparisonKind = ComparisonKind.OperatorEquals;
+                        hashKind = HashKind.ScalarValueType;
+                        initializationKind = InitializationKind.SimpleAssign;
+                        type = MakeProperNumberType(_generateJsonNumberAs);
                         break;
 
                     case SchemaType.Integer:
@@ -718,6 +726,19 @@ namespace Microsoft.Json.Schema.ToDotNet
                     return SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword));
                 default:
                     return SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword));
+            }
+        }
+
+        internal TypeSyntax MakeProperNumberType(GenerateJsonNumberOption generateJsonNumberAs)
+        {
+            switch (generateJsonNumberAs)
+            {
+                case GenerateJsonNumberOption.Float:
+                    return SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.FloatKeyword));
+                case GenerateJsonNumberOption.Decimal:
+                    return SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.DecimalKeyword));
+                default:
+                    return SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.DoubleKeyword));
             }
         }
     }

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # Microsoft Json Schema Packages
 
+## **Unreleased**
+* FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`. [#165](https://github.com/microsoft/jschema/pull/165)
+
 ## **2.1.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.1.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.1.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.1.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.1.0)
 * FEATURE: Add support for JSON Schema type `uuid` generate as C# nullable `Guid?`. [#164](https://github.com/microsoft/jschema/pull/164)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # Microsoft Json Schema Packages
 
 ## **Unreleased**
-* FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`. [#165](https://github.com/microsoft/jschema/pull/165)
+* FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`. [#166](https://github.com/microsoft/jschema/pull/166)
 
 ## **2.1.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.1.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.1.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.1.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.1.0)
 * FEATURE: Add support for JSON Schema type `uuid` generate as C# nullable `Guid?`. [#164](https://github.com/microsoft/jschema/pull/164)


### PR DESCRIPTION
FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`. (before change it was fixed as `double`.)

Background: The difference can be seem here
[integer](https://json-schema.org/understanding-json-schema/reference/numeric.html#integer)
[number](https://json-schema.org/understanding-json-schema/reference/numeric.html#number)

This change added the option for user to generate the C# class `double | float | decimal` as suitable, for Json `number`.
Before this change, there is no option and only produce C# class `double` for Json `number`.
(Whether the class of the choice is suitable or not, is outside of the scope of this code generation tool, 
and is decided by the user of the tool, 
according to the target project to put the generated code in. 
e.g. the target project use decimals, if our tool only support double, they will need to do the cast back and forth.)
