### PR TITLE
* BREAKING: .NET type to express Json integers now will be nullable if the property is not required and also without default.

### DIFF
--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -141,7 +141,7 @@ namespace N
         [DataMember(Name = ""booleanProperty"", IsRequired = false, EmitDefaultValue = false)]
         public bool BooleanProperty { get; set; }
         [DataMember(Name = ""integerProperty"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty { get; set; }
+        public int? IntegerProperty { get; set; }
     }
 }";
 
@@ -212,7 +212,10 @@ namespace N
 
                 result = (result * 31) + obj.NumberProperty.GetHashCode();
                 result = (result * 31) + obj.BooleanProperty.GetHashCode();
-                result = (result * 31) + obj.IntegerProperty.GetHashCode();
+                if (obj.IntegerProperty != null)
+                {
+                    result = (result * 31) + obj.IntegerProperty.GetHashCode();
+                }
             }
 
             return result;
@@ -310,29 +313,29 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""integerProperty_default"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_default { get; set; }
+        public BigInteger? IntegerProperty_default { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_0_max_na { get; set; }
+        public BigInteger? IntegerProperty_min_0_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_minus1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_minus1_max_na { get; set; }
+        public BigInteger? IntegerProperty_min_minus1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_1_max_na { get; set; }
+        public BigInteger? IntegerProperty_min_1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_na_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_na_max_0 { get; set; }
+        public BigInteger? IntegerProperty_min_na_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64times10"", IsRequired = false, EmitDefaultValue = false)]
         public BigInteger IntegerProperty_min_0_max_int64times10 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_int64 { get; set; }
+        public long? IntegerProperty_min_0_max_int64 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32add1"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_int32add1 { get; set; }
+        public long? IntegerProperty_min_0_max_int32add1 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_0_max_int32 { get; set; }
+        public int? IntegerProperty_min_0_max_int32 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_int32_max_0 { get; set; }
+        public int? IntegerProperty_min_int32_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32minus1_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_int32minus1_max_0 { get; set; }
+        public long? IntegerProperty_min_int32minus1_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_int64_max_0 { get; set; }
+        public long? IntegerProperty_min_int64_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64times10_max_0"", IsRequired = false, EmitDefaultValue = false)]
         public BigInteger IntegerProperty_min_int64times10_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_huge_max_0"", IsRequired = false, EmitDefaultValue = false)]
@@ -354,35 +357,35 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""integerProperty_default"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_default { get; set; }
+        public BigInteger? IntegerProperty_default { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_0_max_na { get; set; }
+        public BigInteger? IntegerProperty_min_0_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_minus1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_minus1_max_na { get; set; }
+        public BigInteger? IntegerProperty_min_minus1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_1_max_na { get; set; }
+        public BigInteger? IntegerProperty_min_1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_na_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_na_max_0 { get; set; }
+        public BigInteger? IntegerProperty_min_na_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64times10"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_0_max_int64times10 { get; set; }
+        public BigInteger? IntegerProperty_min_0_max_int64times10 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_0_max_int64 { get; set; }
+        public BigInteger? IntegerProperty_min_0_max_int64 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32add1"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_0_max_int32add1 { get; set; }
+        public BigInteger? IntegerProperty_min_0_max_int32add1 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_0_max_int32 { get; set; }
+        public BigInteger? IntegerProperty_min_0_max_int32 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_int32_max_0 { get; set; }
+        public BigInteger? IntegerProperty_min_int32_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32minus1_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_int32minus1_max_0 { get; set; }
+        public BigInteger? IntegerProperty_min_int32minus1_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_int64_max_0 { get; set; }
+        public BigInteger? IntegerProperty_min_int64_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64times10_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_int64times10_max_0 { get; set; }
+        public BigInteger? IntegerProperty_min_int64times10_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_huge_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_huge_max_0 { get; set; }
+        public BigInteger? IntegerProperty_min_huge_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_huge"", IsRequired = false, EmitDefaultValue = false)]
-        public BigInteger IntegerProperty_min_0_max_huge { get; set; }
+        public BigInteger? IntegerProperty_min_0_max_huge { get; set; }
     }
 }";
             const string ExpectedClass_Long =
@@ -397,35 +400,35 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""integerProperty_default"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_default { get; set; }
+        public long? IntegerProperty_default { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_na { get; set; }
+        public long? IntegerProperty_min_0_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_minus1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_minus1_max_na { get; set; }
+        public long? IntegerProperty_min_minus1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_1_max_na { get; set; }
+        public long? IntegerProperty_min_1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_na_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_na_max_0 { get; set; }
+        public long? IntegerProperty_min_na_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64times10"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_int64times10 { get; set; }
+        public long? IntegerProperty_min_0_max_int64times10 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_int64 { get; set; }
+        public long? IntegerProperty_min_0_max_int64 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32add1"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_int32add1 { get; set; }
+        public long? IntegerProperty_min_0_max_int32add1 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_int32 { get; set; }
+        public long? IntegerProperty_min_0_max_int32 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_int32_max_0 { get; set; }
+        public long? IntegerProperty_min_int32_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32minus1_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_int32minus1_max_0 { get; set; }
+        public long? IntegerProperty_min_int32minus1_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_int64_max_0 { get; set; }
+        public long? IntegerProperty_min_int64_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64times10_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_int64times10_max_0 { get; set; }
+        public long? IntegerProperty_min_int64times10_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_huge_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_huge_max_0 { get; set; }
+        public long? IntegerProperty_min_huge_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_huge"", IsRequired = false, EmitDefaultValue = false)]
-        public long IntegerProperty_min_0_max_huge { get; set; }
+        public long? IntegerProperty_min_0_max_huge { get; set; }
     }
 }";
             const string ExpectedClass_Int =
@@ -440,35 +443,35 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""integerProperty_default"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_default { get; set; }
+        public int? IntegerProperty_default { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_0_max_na { get; set; }
+        public int? IntegerProperty_min_0_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_minus1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_minus1_max_na { get; set; }
+        public int? IntegerProperty_min_minus1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_1_max_na"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_1_max_na { get; set; }
+        public int? IntegerProperty_min_1_max_na { get; set; }
         [DataMember(Name = ""integerProperty_min_na_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_na_max_0 { get; set; }
+        public int? IntegerProperty_min_na_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64times10"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_0_max_int64times10 { get; set; }
+        public int? IntegerProperty_min_0_max_int64times10 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int64"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_0_max_int64 { get; set; }
+        public int? IntegerProperty_min_0_max_int64 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32add1"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_0_max_int32add1 { get; set; }
+        public int? IntegerProperty_min_0_max_int32add1 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_int32"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_0_max_int32 { get; set; }
+        public int? IntegerProperty_min_0_max_int32 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_int32_max_0 { get; set; }
+        public int? IntegerProperty_min_int32_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int32minus1_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_int32minus1_max_0 { get; set; }
+        public int? IntegerProperty_min_int32minus1_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_int64_max_0 { get; set; }
+        public int? IntegerProperty_min_int64_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_int64times10_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_int64times10_max_0 { get; set; }
+        public int? IntegerProperty_min_int64times10_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_huge_max_0"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_huge_max_0 { get; set; }
+        public int? IntegerProperty_min_huge_max_0 { get; set; }
         [DataMember(Name = ""integerProperty_min_0_max_huge"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty_min_0_max_huge { get; set; }
+        public int? IntegerProperty_min_0_max_huge { get; set; }
     }
 }";
             GeneratesPropertiesWithIntegerTypes_Helper(GenerateJsonIntegerOption.Auto, ExpectedClass_Auto);
@@ -1347,19 +1350,19 @@ namespace N
         /// The value of the R component.
         /// </summary>
         [DataMember(Name = ""red"", IsRequired = false, EmitDefaultValue = false)]
-        public int Red { get; set; }
+        public int? Red { get; set; }
 
         /// <summary>
         /// The value of the G component.
         /// </summary>
         [DataMember(Name = ""green"", IsRequired = false, EmitDefaultValue = false)]
-        public int Green { get; set; }
+        public int? Green { get; set; }
 
         /// <summary>
         /// The value of the B component.
         /// </summary>
         [DataMember(Name = ""blue"", IsRequired = false, EmitDefaultValue = false)]
-        public int Blue { get; set; }
+        public int? Blue { get; set; }
     }
 }";
 
@@ -1418,9 +1421,20 @@ namespace N
             int result = 17;
             unchecked
             {
-                result = (result * 31) + obj.Red.GetHashCode();
-                result = (result * 31) + obj.Green.GetHashCode();
-                result = (result * 31) + obj.Blue.GetHashCode();
+                if (obj.Red != null)
+                {
+                    result = (result * 31) + obj.Red.GetHashCode();
+                }
+
+                if (obj.Green != null)
+                {
+                    result = (result * 31) + obj.Green.GetHashCode();
+                }
+
+                if (obj.Blue != null)
+                {
+                    result = (result * 31) + obj.Blue.GetHashCode();
+                }
             }
 
             return result;
@@ -1758,7 +1772,7 @@ namespace N
         /// An integer property.
         /// </summary>
         [DataMember(Name = ""integerProperty"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty { get; set; }
+        public int? IntegerProperty { get; set; }
 
         /// <summary>
         /// An integer property with a default value.
@@ -1976,7 +1990,7 @@ namespace N
         /// <param name=""dictionaryWithHintedValueProp"">
         /// An initialization value for the <see cref=""P:DictionaryWithHintedValueProp"" /> property.
         /// </param>
-        public C(int integerProperty, int integerPropertyWithDefault, double numberProperty, double numberPropertyWithDefault, string stringProperty, string stringPropertyWithDefault, bool booleanProperty, bool booleanPropertyWithTrueDefault, bool booleanPropertyWithFalseDefault, Color enumeratedPropertyWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        public C(int? integerProperty, int integerPropertyWithDefault, double numberProperty, double numberPropertyWithDefault, string stringProperty, string stringPropertyWithDefault, bool booleanProperty, bool booleanPropertyWithTrueDefault, bool booleanPropertyWithFalseDefault, Color enumeratedPropertyWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
             Init(integerProperty, integerPropertyWithDefault, numberProperty, numberPropertyWithDefault, stringProperty, stringPropertyWithDefault, booleanProperty, booleanPropertyWithTrueDefault, booleanPropertyWithFalseDefault, enumeratedPropertyWithDefault, arrayProp, uriProp, dateTimeProp, referencedTypeProp, arrayOfRefProp, arrayOfArrayProp, dictionaryProp, dictionaryWithPrimitiveSchemaProp, dictionaryWithObjectSchemaProp, dictionaryWithObjectArraySchemaProp, dictionaryWithUriKeyProp, dictionaryWithHintedValueProp);
         }
@@ -2018,7 +2032,7 @@ namespace N
             return new C(this);
         }
 
-        private void Init(int integerProperty, int integerPropertyWithDefault, double numberProperty, double numberPropertyWithDefault, string stringProperty, string stringPropertyWithDefault, bool booleanProperty, bool booleanPropertyWithTrueDefault, bool booleanPropertyWithFalseDefault, Color enumeratedPropertyWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
+        private void Init(int? integerProperty, int integerPropertyWithDefault, double numberProperty, double numberPropertyWithDefault, string stringProperty, string stringPropertyWithDefault, bool booleanProperty, bool booleanPropertyWithTrueDefault, bool booleanPropertyWithFalseDefault, Color enumeratedPropertyWithDefault, IEnumerable<double> arrayProp, Uri uriProp, DateTime dateTimeProp, D referencedTypeProp, IEnumerable<D> arrayOfRefProp, IEnumerable<IEnumerable<D>> arrayOfArrayProp, IDictionary<string, string> dictionaryProp, IDictionary<string, double> dictionaryWithPrimitiveSchemaProp, IDictionary<string, D> dictionaryWithObjectSchemaProp, IDictionary<string, IList<D>> dictionaryWithObjectArraySchemaProp, IDictionary<Uri, D> dictionaryWithUriKeyProp, IDictionary<string, V> dictionaryWithHintedValueProp)
         {
             IntegerProperty = integerProperty;
             IntegerPropertyWithDefault = integerPropertyWithDefault;
@@ -2655,7 +2669,7 @@ namespace N
         public static IComparer<Def2> Comparer => Def2Comparer.Instance;
 
         [DataMember(Name = ""prop2"", IsRequired = false, EmitDefaultValue = false)]
-        public int Prop2 { get; set; }
+        public int? Prop2 { get; set; }
     }
 }";
 
@@ -2704,7 +2718,10 @@ namespace N
             int result = 17;
             unchecked
             {
-                result = (result * 31) + obj.Prop2.GetHashCode();
+                if (obj.Prop2 != null)
+                {
+                    result = (result * 31) + obj.Prop2.GetHashCode();
+                }
             }
 
             return result;
@@ -3268,7 +3285,7 @@ namespace N
         public static IComparer<C> Comparer => CComparer.Instance;
 
         [DataMember(Name = ""intDefProp"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntDefProp { get; set; }
+        public int? IntDefProp { get; set; }
     }
 }";
             const string ExpectedEqualityComparerClass =
@@ -3316,7 +3333,10 @@ namespace N
             int result = 17;
             unchecked
             {
-                result = (result * 31) + obj.IntDefProp.GetHashCode();
+                if (obj.IntDefProp != null)
+                {
+                    result = (result * 31) + obj.IntDefProp.GetHashCode();
+                }
             }
 
             return result;
@@ -3398,6 +3418,15 @@ namespace N
       ""description"": ""An integer property with a default value."",
       ""default"": 42
     },
+    ""integerPropertyRequired"": {
+      ""type"": ""integer"",
+      ""description"": ""An integer property with a default value.""
+    },
+    ""integerPropertyRequiredAndWithDefault"": {
+      ""type"": ""integer"",
+      ""description"": ""An integer property with a default value."",
+      ""default"": 42
+    },
     ""numberProperty"": {
       ""type"": ""number"",
       ""description"": ""A number property.""
@@ -3438,7 +3467,8 @@ namespace N
       },
       ""default"": []
     }
-  }
+  },
+  ""required"": [ ""integerPropertyRequired"", ""integerPropertyRequiredAndWithDefault"" ]
 }";
             const string ExpectedClass =
 @"using System;
@@ -3458,7 +3488,7 @@ namespace N
         /// An integer property.
         /// </summary>
         [DataMember(Name = ""integerProperty"", IsRequired = false, EmitDefaultValue = false)]
-        public int IntegerProperty { get; set; }
+        public int? IntegerProperty { get; set; }
 
         /// <summary>
         /// An integer property with a default value.
@@ -3467,6 +3497,20 @@ namespace N
         [DefaultValue(42)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         public int IntegerPropertyWithDefault { get; set; }
+
+        /// <summary>
+        /// An integer property with a default value.
+        /// </summary>
+        [DataMember(Name = ""integerPropertyRequired"", IsRequired = true)]
+        public int IntegerPropertyRequired { get; set; }
+
+        /// <summary>
+        /// An integer property with a default value.
+        /// </summary>
+        [DataMember(Name = ""integerPropertyRequiredAndWithDefault"", IsRequired = true)]
+        [DefaultValue(42)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        public int IntegerPropertyRequiredAndWithDefault { get; set; }
 
         /// <summary>
         /// A number property.

--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -3420,11 +3420,11 @@ namespace N
     },
     ""integerPropertyRequired"": {
       ""type"": ""integer"",
-      ""description"": ""An integer property with a default value.""
+      ""description"": ""An integer property, required.""
     },
     ""integerPropertyRequiredAndWithDefault"": {
       ""type"": ""integer"",
-      ""description"": ""An integer property with a default value."",
+      ""description"": ""An integer property, required and with a default value."",
       ""default"": 42
     },
     ""numberProperty"": {
@@ -3499,13 +3499,13 @@ namespace N
         public int IntegerPropertyWithDefault { get; set; }
 
         /// <summary>
-        /// An integer property with a default value.
+        /// An integer property, required.
         /// </summary>
         [DataMember(Name = ""integerPropertyRequired"", IsRequired = true)]
         public int IntegerPropertyRequired { get; set; }
 
         /// <summary>
-        /// An integer property with a default value.
+        /// An integer property, required and with a default value.
         /// </summary>
         [DataMember(Name = ""integerPropertyRequiredAndWithDefault"", IsRequired = true)]
         [DefaultValue(42)]

--- a/src/Json.Schema.ToDotNet.UnitTests/Hints/AttributeHintTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/Hints/AttributeHintTests.cs
@@ -43,7 +43,7 @@ namespace N
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
         [Test]
-        public int TheProperty { get; set; }
+        public int? TheProperty { get; set; }
     }
 }"
             ),
@@ -85,7 +85,7 @@ namespace N
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
         [Test(typeof(string))]
-        public int TheProperty { get; set; }
+        public int? TheProperty { get; set; }
     }
 }"
             ),
@@ -129,7 +129,7 @@ namespace N
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
         [Test(typeof(string), 42, ""a"")]
-        public int TheProperty { get; set; }
+        public int? TheProperty { get; set; }
     }
 }"
             ),
@@ -171,7 +171,7 @@ namespace N
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
         [Test(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int TheProperty { get; set; }
+        public int? TheProperty { get; set; }
     }
 }"
             ),
@@ -214,7 +214,7 @@ namespace N
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
         [Test(DefaultValueHandling = DefaultValueHandling.Ignore, DefaultValue = 42)]
-        public int TheProperty { get; set; }
+        public int? TheProperty { get; set; }
     }
 }"
             ),
@@ -260,7 +260,7 @@ namespace N
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
         [Test1]
         [Test2]
-        public int TheProperty { get; set; }
+        public int? TheProperty { get; set; }
     }
 }"
             ),
@@ -301,7 +301,7 @@ namespace N
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
         [Test]
-        public int TheProperty { get; set; }
+        public int? TheProperty { get; set; }
     }
 }"
             ),

--- a/src/Json.Schema.ToDotNet.UnitTests/Hints/InterfaceHintTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/Hints/InterfaceHintTests.cs
@@ -69,13 +69,13 @@ namespace N
         /// The value.
         /// </summary>
         [DataMember(Name = ""value"", IsRequired = false, EmitDefaultValue = false)]
-        public int Value { get; set; }
+        public int? Value { get; set; }
 
         /// <summary>
         /// Internal value.
         /// </summary>
         [DataMember(Name = ""value2"", IsRequired = false, EmitDefaultValue = false)]
-        internal int Value2 { get; set; }
+        internal int? Value2 { get; set; }
     }
 }",
 
@@ -92,7 +92,7 @@ namespace N
         /// <summary>
         /// The value.
         /// </summary>
-        int Value { get; }
+        int? Value { get; }
     }
 }"
             }

--- a/src/Json.Schema.ToDotNet.UnitTests/Hints/PropertyModifiersHintTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/Hints/PropertyModifiersHintTests.cs
@@ -43,7 +43,7 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
-        int TheProperty { get; set; }
+        int? TheProperty { get; set; }
     }
 }"
             ),
@@ -83,7 +83,7 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
-        internal int TheProperty { get; set; }
+        internal int? TheProperty { get; set; }
     }
 }"
             ),
@@ -124,7 +124,7 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
-        internal override int TheProperty { get; set; }
+        internal override int? TheProperty { get; set; }
     }
 }"
             ),
@@ -194,7 +194,7 @@ namespace N
     public partial class C
     {
         [DataMember(Name = ""theProperty"", IsRequired = false, EmitDefaultValue = false)]
-        internal override int TheProperty { get; set; }
+        internal override int? TheProperty { get; set; }
     }
 }"
             ),

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,7 @@
 # Microsoft Json Schema Packages
 
 ## **Unreleased**
+* BREAKING: .NET type to express Json integers now will be nullable if the property is not required and also without default. [#167](https://github.com/microsoft/jschema/pull/167)
 * FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`. [#166](https://github.com/microsoft/jschema/pull/166)
 
 ## **2.1.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.1.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.1.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.1.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.1.0)


### PR DESCRIPTION
Purpose of this change:
Ran through SARIF SDK looks good to remove all those:
`// NOTYETAUTOGENERATED: Property should be nullable int. https://github.com/Microsoft/jschema/issues/112`
https://github.com/Microsoft/jschema/issues/112
And also nullable `BigInteger`. 

Modified existing test case, and add a test in `GeneratesAttributesForPropertiesOfPrimitiveTypeWithDefaults()`
