### PR TITLE
Releasing 2.2.0

### DIFF
--- a/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/DataModelGeneratorTests.cs
@@ -491,7 +491,7 @@ using System.Runtime.Serialization;
 namespace N
 {
     [DataContract]
-    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.1.0.0"")]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", """ + VersionConstants.FileVersion + @""")]
     public partial class C
     {
         [DataMember(Name = ""numberProperty_default"", IsRequired = false, EmitDefaultValue = false)]
@@ -534,7 +534,7 @@ using System.Runtime.Serialization;
 namespace N
 {
     [DataContract]
-    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.1.0.0"")]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", """ + VersionConstants.FileVersion + @""")]
     public partial class C
     {
         [DataMember(Name = ""numberProperty_default"", IsRequired = false, EmitDefaultValue = false)]
@@ -577,7 +577,7 @@ using System.Runtime.Serialization;
 namespace N
 {
     [DataContract]
-    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", ""2.1.0.0"")]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", """ + VersionConstants.FileVersion + @""")]
     public partial class C
     {
         [DataMember(Name = ""numberProperty_default"", IsRequired = false, EmitDefaultValue = false)]

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # Microsoft Json Schema Packages
 
-## **Unreleased**
+## **2.2.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.2.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.2.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.2.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.2.0)
 * BREAKING: .NET type to express Json integers now will be nullable if the property is not required and also without default. [#167](https://github.com/microsoft/jschema/pull/167)
 * FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`. [#166](https://github.com/microsoft/jschema/pull/166)
 

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
     <Company Condition=" '$(Company)' == '' ">Microsoft</Company>
     <Product Condition=" '$(Product)' == '' ">JSON Schema</Product>
     <Copyright Condition=" '$(Copyright)' == '' ">© Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
# Microsoft Json Schema Packages

## **2.2.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.2.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.2.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.2.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.2.0)
* BREAKING: .NET type to express Json integers now will be nullable if the property is not required and also without default. [#167](https://github.com/microsoft/jschema/pull/167)
* FEATURE: Add new option for specifying .NET type to express Json numbers: `--generate-json-number-as = double | float | decimal` with a default of `double`. [#166](https://github.com/microsoft/jschema/pull/166)
