### PR TITLE
Added support to validate Json against string format attribute from JSON Schema

### DIFF
--- a/src/Json.Schema.Validation.UnitTests/ValidatorTests.cs
+++ b/src/Json.Schema.Validation.UnitTests/ValidatorTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Json.Schema.TestUtilities;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.Json.Schema.Validation.UnitTests
 {

--- a/src/Json.Schema.Validation.UnitTests/ValidatorTests.cs
+++ b/src/Json.Schema.Validation.UnitTests/ValidatorTests.cs
@@ -1091,6 +1091,22 @@ namespace Microsoft.Json.Schema.Validation.UnitTests
                 "\"https://www.example.com\""
                 ),
             new TestCase(
+                "String: format: valid with file uri format constraint",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uri""
+                }",
+                "\"file://localhost/absolute/path/to/file\""
+                ),
+            new TestCase(
+                "String: format: valid with email uri format constraint",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uri""
+                }",
+                "\"mailto:jsmith@example.com?subject=A%20Test&body=My%20idea%20is%3A%20%0A\""
+                ),
+            new TestCase(
                 "String: format: Invalid uri value",
                 @"{
                   ""type"": ""string"",
@@ -1142,7 +1158,7 @@ namespace Microsoft.Json.Schema.Validation.UnitTests
                 MakeErrorMessage(1, 34, string.Empty, ErrorNumber.StringDoesNotMatchFormat, FormatAttributes.Uuid, "4014-4666-449e-afc4-1b82fbfb27ad")
                 )
         };
-
+        
         [Theory(DisplayName = "Validation")]
         [MemberData(nameof(TestCases))]
         public void Tests(TestCase test)

--- a/src/Json.Schema.Validation.UnitTests/ValidatorTests.cs
+++ b/src/Json.Schema.Validation.UnitTests/ValidatorTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Json.Schema.TestUtilities;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.Json.Schema.Validation.UnitTests
 {
@@ -1064,6 +1065,82 @@ namespace Microsoft.Json.Schema.Validation.UnitTests
   }
 }",
                 MakeErrorMessage(2, 8, "a", ErrorNumber.DependentPropertyMissing, "x", "\"y\"", "\"y\"")
+                ),
+            new TestCase(
+                "String: format: valid with date-time format constraints",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""date-time""
+                }",
+                "\"2023-02-03T12:34:56.789Z\""
+                ),
+            new TestCase(
+                "String: format: invalid date-time format string",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""date-time""
+                }",
+                "\"failure-string\"",
+                MakeErrorMessage(1, 16, string.Empty, ErrorNumber.StringDoesNotMatchFormat, FormatAttributes.DateTime, "failure-string")
+                ),
+            new TestCase(
+                "String: format: valid with uri format constraint",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uri""
+                }",
+                "\"https://www.example.com\""
+                ),
+            new TestCase(
+                "String: format: Invalid uri value",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uri""
+                }",
+                "\"sites/files/images/picture.png\"",
+                MakeErrorMessage(1, 32, string.Empty, ErrorNumber.StringDoesNotMatchFormat, FormatAttributes.Uri, "sites/files/images/picture.png")
+                ),
+            new TestCase(
+                "String: format: valid with uri-reference format constraint",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uri-reference""
+                }",
+                "\"sites/files/images/picture.png\""
+                ),
+            new TestCase(
+                "String: format: Invalid with uri-reference format constraint",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uri-reference""
+                }",
+                "\"````\"",
+                MakeErrorMessage(1, 6, string.Empty, ErrorNumber.StringDoesNotMatchFormat, FormatAttributes.UriReference, "````")
+                ),
+            new TestCase(
+                "String: format: valid with uuid format constraint - lowercase",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uuid""
+                }",
+                "\"8b524014-4666-449e-afc4-1b82fbfb27ad\""
+                ),
+            new TestCase(
+                "String: format: valid with uuid format constraint - uppercase",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uuid""
+                }",
+                "\"6303D187-07A8-4164-864F-0C01D6F8E5C4\""
+                ),
+            new TestCase(
+                "String: format: Invalid with uuid format constraint",
+                @"{
+                  ""type"": ""string"",
+                  ""format"": ""uuid""
+                }",
+                "\"4014-4666-449e-afc4-1b82fbfb27ad\"",
+                MakeErrorMessage(1, 34, string.Empty, ErrorNumber.StringDoesNotMatchFormat, FormatAttributes.Uuid, "4014-4666-449e-afc4-1b82fbfb27ad")
                 )
         };
 

--- a/src/Json.Schema.Validation/RuleFactory.cs
+++ b/src/Json.Schema.Validation/RuleFactory.cs
@@ -198,7 +198,12 @@ namespace Microsoft.Json.Schema.Validation
             [ErrorNumber.DependentPropertyMissing] = MakeRule(
                 ErrorNumber.DependentPropertyMissing,
                 RuleResources.RuleDescriptionDependentPropertyMissing,
-                RuleResources.ErrorDependentPropertyMissing)
+                RuleResources.ErrorDependentPropertyMissing),
+
+            [ErrorNumber.StringDoesNotMatchFormat] = MakeRule(
+                ErrorNumber.StringDoesNotMatchFormat,
+                RuleResources.RuleDescriptionStringDoesNotMatchFormat,
+                RuleResources.ErrorStringDoesNotMatchFormat)
         });
 
         public static ReportingDescriptor GetRuleFromRuleId(string ruleId)

--- a/src/Json.Schema.Validation/RuleResources.Designer.cs
+++ b/src/Json.Schema.Validation/RuleResources.Designer.cs
@@ -357,7 +357,18 @@ namespace Microsoft.Json.Schema.Validation {
                 return ResourceManager.GetString("ErrorWrongType", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The schema requires string value of the format &quot;{1}&quot;, but a token value &quot;{2}&quot; was found...
+        /// </summary>
+        internal static string ErrorStringDoesNotMatchFormat
+        {
+            get
+            {
+                return ResourceManager.GetString("ErrorStringDoesNotMatchFormat", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to An object contains a property not defined by the schema is present, and the schema does not permit additional properties..
         /// </summary>
@@ -643,6 +654,17 @@ namespace Microsoft.Json.Schema.Validation {
         internal static string RuleDescriptionWrongType {
             get {
                 return ResourceManager.GetString("RuleDescriptionWrongType", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to An string value has a format that is not permitted by the schema&apos;s &quot;format&quot; property..
+        /// </summary>
+        internal static string RuleDescriptionStringDoesNotMatchFormat
+        {
+            get
+            {
+                return ResourceManager.GetString("RuleDescriptionStringDoesNotMatchFormat", resourceCulture);
             }
         }
     }

--- a/src/Json.Schema.Validation/RuleResources.resx
+++ b/src/Json.Schema.Validation/RuleResources.resx
@@ -217,6 +217,9 @@
   <data name="ErrorWrongType" xml:space="preserve">
     <value>The schema requires one of the types [{1}], but a token of type '{2}' was found.</value>
   </data>
+  <data name="ErrorStringDoesNotMatchFormat" xml:space="preserve">
+    <value>The schema requires string value of the format '{1}', but a token value '{2}' was found.</value>
+  </data>
   <data name="RuleDescriptionAdditionalPropertiesProhibited" xml:space="preserve">
     <value>An object contains a property not defined by the schema, and the schema does not permit additional properties.</value>
   </data>
@@ -312,5 +315,8 @@
   </data>
   <data name="RuleDescriptionWrongType" xml:space="preserve">
     <value>An instance has a type that is not permitted by the schema's 'type' property.</value>
+  </data>
+  <data name="RuleDescriptionStringDoesNotMatchFormat" xml:space="preserve">
+    <value>A string value has a format that is not permitted by the schema's 'format' property.</value>
   </data>
 </root>

--- a/src/Json.Schema.Validation/Validator.cs
+++ b/src/Json.Schema.Validation/Validator.cs
@@ -181,6 +181,44 @@ namespace Microsoft.Json.Schema.Validation
                     AddResult(jValue, ErrorNumber.StringDoesNotMatchPattern, value, schema.Pattern);
                 }
             }
+
+            if(!string.IsNullOrEmpty(schema.Format))
+            {
+                ValidateStringFormat(jValue, schema.Format);
+            }
+        }
+
+        private void ValidateStringFormat(JValue jValue, string format)
+        {
+            string value = jValue.Value<string>();
+            if (string.Compare(format, FormatAttributes.DateTime) == 0)
+            {
+                if (!DateTime.TryParse(value, out DateTime _))
+                {
+                    AddResult(jValue, ErrorNumber.StringDoesNotMatchFormat, format, value);
+                }
+            } 
+            else if(string.Compare(format, FormatAttributes.Uri) == 0)
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.Absolute))
+                {
+                    AddResult(jValue, ErrorNumber.StringDoesNotMatchFormat, format, value);
+                }
+            }
+            else if(string.Compare(format, FormatAttributes.UriReference) == 0)
+            {
+                if (!Uri.IsWellFormedUriString(value, UriKind.RelativeOrAbsolute))
+                {
+                    AddResult(jValue, ErrorNumber.StringDoesNotMatchFormat, format, value);
+                }
+            }
+            else if (string.Compare(format, FormatAttributes.Uuid) == 0)
+            {
+                if (!Guid.TryParse(value, out Guid _))
+                {
+                    AddResult(jValue, ErrorNumber.StringDoesNotMatchFormat, format, value);
+                }
+            }
         }
 
         // Compute the length of a string, counting surrogate pairs as one

--- a/src/Json.Schema/ErrorNumber.cs
+++ b/src/Json.Schema/ErrorNumber.cs
@@ -474,7 +474,27 @@ namespace Microsoft.Json.Schema
         /// The instance contains a property specified by "dependencies", but it does
         /// not contain all the properties specified by the corresponding property dependency.
         /// </summary>
-        DependentPropertyMissing = 1023
+        DependentPropertyMissing = 1023,
+
+
+        /// <summary>
+        /// A string instance does not match the required format.
+        /// </summary>
+        /// <example>
+        /// Schema:
+        /// <code>
+        /// {
+        ///   "type": "string",
+        ///   "format": "date-time"
+        /// }
+        /// </code>
+        /// 
+        /// Instance:
+        /// <code>
+        /// "2023-02-03:T12:00:00Z"
+        /// </code>
+        /// </example>
+        StringDoesNotMatchFormat = 1024,
 
         #endregion Errors in instance document
     }


### PR DESCRIPTION
Added string format validation for date-time, uri, uri-reference and uuid
Added error-messages and localization keys in English
Updated test cases to test validation for the format attribute
Tagging @shaopeng-gh and @michaelcfanning  for review
For example - The following schema validates the date-time format string value.
"String: format: valid with date-time format constraints",
    @"{
      ""type"": ""string"",
      ""format"": ""date-time""
    }",
    "\"2023-02-03T12:34:56.789Z\""