### PR TITLE
Fix `PropertyNameHint` not functional when Pascal case is used.

### DIFF
--- a/src/Json.Schema.ToDotNet.UnitTests/Hints/PropertyNameHintTests.cs
+++ b/src/Json.Schema.ToDotNet.UnitTests/Hints/PropertyNameHintTests.cs
@@ -46,6 +46,44 @@ namespace N
         public Uri SchemaUri { get; set; }
     }
 }"
+            ),
+
+            new HintTestCase(
+                "Specifies integer property name",
+@"{
+  ""type"": ""object"",
+  ""properties"": {
+    ""itemCount"": {
+      ""type"": ""integer""
+    }
+  }
+}",
+
+@"{
+  ""C.ItemCount"": [
+    {
+      ""kind"": ""PropertyNameHint"",
+      ""arguments"": {
+        ""dotNetPropertyName"": ""RenamedItemCount""
+      }
+    }
+  ]
+}",
+
+@"using System;
+using System.CodeDom.Compiler;
+using System.Runtime.Serialization;
+
+namespace N
+{
+    [DataContract]
+    [GeneratedCode(""Microsoft.Json.Schema.ToDotNet"", """ + VersionConstants.FileVersion + @""")]
+    public partial class C
+    {
+        [DataMember(Name = ""itemCount"", IsRequired = false, EmitDefaultValue = false)]
+        public int? RenamedItemCount { get; set; }
+    }
+}"
             )
         };
 

--- a/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
+++ b/src/Json.Schema.ToDotNet/PropertyInfoDictionary.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Json.Schema.ToDotNet
                 }
             }
 
-            var propertyNameHint = _hintDictionary?.GetHint<PropertyNameHint>(_typeName + "." + schemaPropertyName);
+            var propertyNameHint = _hintDictionary?.GetHint<PropertyNameHint>(_typeName + "." + schemaPropertyName.ToPascalCase());
             string dotNetPropertyName = propertyNameHint != null
                 ? propertyNameHint.DotNetPropertyName
                 : schemaPropertyName.ToPascalCase();

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # Microsoft Json Schema Packages
 
+## **2.3.1** UNRELEASED
+* BUG: Hint file should be consistent and use Pascal case. Fix `PropertyNameHint` not effective when Pascal case is used. [#172](https://github.com/microsoft/jschema/pull/172)
+
 ## **2.3.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.3.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.3.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.3.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.3.0)
 * FEATURE: Added support to validate JSON against string format attribute from JSON Schema. [#169](https://github.com/microsoft/jschema/pull/169)
 

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # Microsoft Json Schema Packages
 
 ## **2.3.1** UNRELEASED
-* BUG: Hint file should be consistent and use Pascal case. Fix `PropertyNameHint` not effective when Pascal case is used. [#173](https://github.com/microsoft/jschema/pull/173)
+* BUG: Hint file should be consistent and use Pascal case. Fix `PropertyNameHint` not functional when Pascal case is used. [#173](https://github.com/microsoft/jschema/pull/173)
 
 ## **2.3.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.3.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.3.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.3.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.3.0)
 * FEATURE: Added support to validate JSON against string format attribute from JSON Schema. [#169](https://github.com/microsoft/jschema/pull/169)

--- a/src/ReleaseHistory.md
+++ b/src/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # Microsoft Json Schema Packages
 
 ## **2.3.1** UNRELEASED
-* BUG: Hint file should be consistent and use Pascal case. Fix `PropertyNameHint` not effective when Pascal case is used. [#172](https://github.com/microsoft/jschema/pull/172)
+* BUG: Hint file should be consistent and use Pascal case. Fix `PropertyNameHint` not effective when Pascal case is used. [#173](https://github.com/microsoft/jschema/pull/173)
 
 ## **2.3.0** [Pointer](https://www.nuget.org/packages/Microsoft.Json.Pointer/2.3.0) | [Schema](https://www.nuget.org/packages/Microsoft.Json.Schema/2.3.0)| [Schema.ToDotNet](https://www.nuget.org/packages/Microsoft.Json.Schema.ToDotNet/2.3.0)| [Schema.Validation](https://www.nuget.org/packages/Microsoft.Json.Schema.Validation/2.3.0)
 * FEATURE: Added support to validate JSON against string format attribute from JSON Schema. [#169](https://github.com/microsoft/jschema/pull/169)


### PR DESCRIPTION
BUG: Hint file should be consistent and use Pascal case. 
Fix `PropertyNameHint` not functional when Pascal case is used.
I can see most of our hint file definition use Pascal case: `Parent1.Child1`. If this is not correct, let me know.
Without this fix, hint file definition will need to use `Parent1.child1` to be functional.
There could be other places having the same case issue. Let me know if this fix is correct I can search and fix if there are any others.